### PR TITLE
feat: add auto-assign workflow for PRs and issues

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,38 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Assign issue to owner
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['${{ github.repository_owner }}']
+            });
+
+      - name: Assign PR to owner
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: ['${{ github.repository_owner }}']
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that automatically assigns all new PRs and issues to the repository owner

## Test plan
- [ ] Merge PR and verify it's auto-assigned
- [ ] Open a test issue and verify it's auto-assigned

🤖 Generated with [Claude Code](https://claude.com/claude-code)