### PR TITLE
refactor: rename HF types to LiteLLM types

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -9,7 +9,7 @@ import {
 	ProvideLanguageModelChatResponseOptions,
 } from "vscode";
 
-import type { HFModelItem, HFModelsResponse, HFProvider } from "./types";
+import type { LiteLLMModelItem, LiteLLMModelsResponse, LiteLLMProvider } from "./types";
 
 import { convertTools, convertMessages, tryParseJSONObject, validateRequest } from "./utils";
 
@@ -95,7 +95,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	 *
 	 * Priority: provider info > workspace settings > hardcoded defaults
 	 */
-	private getTokenConstraints(provider: HFProvider | undefined): {
+	private getTokenConstraints(provider: LiteLLMProvider | undefined): {
 		maxOutputTokens: number;
 		contextLength: number;
 		maxInputTokens: number;
@@ -169,7 +169,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 		}
 		console.log("[LiteLLM Model Provider] Config loaded", { baseUrl: config.baseUrl, hasApiKey: !!config.apiKey });
 
-		let models: HFModelItem[];
+		let models: LiteLLMModelItem[];
 		try {
 			const result = await this.fetchModels(config.apiKey, config.baseUrl);
 			models = result.models;
@@ -333,7 +333,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	 * @param apiKey The LiteLLM API key used to authenticate.
 	 * @param baseUrl The LiteLLM base URL.
 	 */
-	private async fetchModels(apiKey: string, baseUrl: string): Promise<{ models: HFModelItem[] }> {
+	private async fetchModels(apiKey: string, baseUrl: string): Promise<{ models: LiteLLMModelItem[] }> {
 		console.log("[LiteLLM Model Provider] fetchModels called", { baseUrl, hasApiKey: !!apiKey });
 		const modelsList = (async () => {
 			const headers: Record<string, string> = { "User-Agent": this.userAgent };
@@ -373,7 +373,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 					console.error("[LiteLLM Model Provider] Failed to fetch LiteLLM models", err);
 					throw err;
 				}
-				const parsed = (await resp.json()) as HFModelsResponse;
+				const parsed = (await resp.json()) as LiteLLMModelsResponse;
 				console.log("[LiteLLM Model Provider] Parsed response:", {
 					object: parsed.object,
 					modelCount: parsed.data?.length ?? 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface OpenAIChatMessage {
  * A single underlying provider (e.g., together, groq) for a model.
  * This interface represents model capability metadata read from the LiteLLM API.
  */
-export interface HFProvider {
+export interface LiteLLMProvider {
 	provider: string;
 	status: string;
 	supports_tools?: boolean;
@@ -47,25 +47,25 @@ export interface HFProvider {
 /**
  * Architecture information for a model.
  */
-export interface HFArchitecture {
+export interface LiteLLMArchitecture {
 	input_modalities?: string[];
 	output_modalities?: string[];
 }
 
-export interface HFModelItem {
+export interface LiteLLMModelItem {
 	id: string;
 	object: string;
 	created: number;
 	owned_by: string;
-	providers: HFProvider[];
-	architecture?: HFArchitecture;
+	providers: LiteLLMProvider[];
+	architecture?: LiteLLMArchitecture;
 }
 
 /**
  * Extra model information (deprecated).
  */
 // Deprecated: extra model info was previously fetched from external APIs
-export interface HFExtraModelInfo {
+export interface LiteLLMExtraModelInfo {
 	id: string;
 	pipeline_tag?: string;
 }
@@ -73,9 +73,9 @@ export interface HFExtraModelInfo {
 /**
  * Response envelope for the LiteLLM models listing.
  */
-export interface HFModelsResponse {
+export interface LiteLLMModelsResponse {
 	object: string;
-	data: HFModelItem[];
+	data: LiteLLMModelItem[];
 }
 
 /**


### PR DESCRIPTION
- Rename HFProvider to LiteLLMProvider
- Rename HFModelItem to LiteLLMModelItem
- Rename HFModelsResponse to LiteLLMModelsResponse
- Rename HFArchitecture to LiteLLMArchitecture
- Rename HFExtraModelInfo to LiteLLMExtraModelInfo
- Update all references throughout codebase