### PR TITLE
feat: add manual trigger for bump-version workflow

### DIFF
--- a/.github/workflows/bump-version-reusable.yml
+++ b/.github/workflows/bump-version-reusable.yml
@@ -2,6 +2,7 @@ name: Bump Version (Reusable)
 
 on:
   workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Added workflow_dispatch trigger to bump-version-reusable.yml, allowing it to be manually triggered from the GitHub Actions UI while maintaining its reusable workflow functionality.