### PR TITLE
Bump engines.vscode to ^1.110.0 and add version guard to CI/pre-commit

### DIFF
--- a/.github/workflows/format-check-reusable.yml
+++ b/.github/workflows/format-check-reusable.yml
@@ -38,3 +38,19 @@ jobs:
 
       - name: Check formatting
         run: bunx prettier --check .
+
+      - name: Verify @types/vscode matches engines.vscode
+        run: |
+          node -e "
+          const pkg = require('./package.json');
+          const engVer = pkg.engines.vscode.replace(/[^0-9.]/g, '');
+          const typesRange = pkg.devDependencies['@types/vscode'];
+          const typesVer = typesRange.replace(/[^0-9.]/g, '');
+          const [eM, em] = engVer.split('.').map(Number);
+          const [tM, tm] = typesVer.split('.').map(Number);
+          if (tM > eM || (tM === eM && tm > em)) {
+            console.error('@types/vscode ' + typesRange + ' is newer than engines.vscode ' + pkg.engines.vscode);
+            process.exit(1);
+          }
+          console.log('engines.vscode ' + pkg.engines.vscode + ' >= @types/vscode ' + typesRange + ' ✓');
+          "

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -23,6 +23,21 @@ fi
 # Lint GitHub Actions workflows
 bun run lint:actions
 
+# Verify @types/vscode matches engines.vscode
+node -e "
+const pkg = require('./package.json');
+const engVer = pkg.engines.vscode.replace(/[^0-9.]/g, '');
+const typesRange = pkg.devDependencies['@types/vscode'];
+const typesVer = typesRange.replace(/[^0-9.]/g, '');
+const [eM, em] = engVer.split('.').map(Number);
+const [tM, tm] = typesVer.split('.').map(Number);
+if (tM > eM || (tM === eM && tm > em)) {
+  console.error('❌ @types/vscode ' + typesRange + ' is newer than engines.vscode ' + pkg.engines.vscode);
+  console.error('   Bump engines.vscode or downgrade @types/vscode to fix.');
+  process.exit(1);
+}
+"
+
 # Run linting
 bun run lint
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"version": "0.2.0",
 	"engines": {
-		"vscode": "^1.108.0"
+		"vscode": "^1.110.0"
 	},
 	"categories": [
 		"AI",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ function isVersionCompatible(current: string, required: string): boolean {
 
 export function activate(context: vscode.ExtensionContext) {
 	// Check VS Code version compatibility
-	const minVersion = "1.108.0";
+	const minVersion = "1.110.0";
 	if (!isVersionCompatible(vscode.version, minVersion)) {
 		vscode.window
 			.showErrorMessage(


### PR DESCRIPTION
The @types/vscode ^1.110.0 devDependency was newer than engines.vscode ^1.108.0, causing vsce package to fail. Bumps the engine minimum and adds a check to both pre-commit hook and CI format-check workflow to catch this mismatch early.