### PR TITLE
v0.2.2: Centralize model defaults with per-model overrides and version bump

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ Tests use the `@vscode/test-electron` framework. Run `bun test` to execute all t
 
 ### Git Commit and PR Conventions
 
-- **DO NOT** add "Co-Authored-By: Codex" or similar attribution lines to commit messages
-- **DO NOT** add "Generated with Codex" or similar markers to pull request descriptions
+- **DO NOT** add "Co-Authored-By:" or similar attribution lines to commit messages
+- **DO NOT** add "Generated with" or similar markers to pull request descriptions
 - Keep commit messages and PR descriptions clean and focused on the actual changes
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,271 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a VS Code extension that integrates LiteLLM into GitHub Copilot Chat, allowing users to access 100+ LLMs (OpenAI, Anthropic, Google, AWS, Azure, etc.) through a unified API. The extension implements VS Code's Language Model Chat Provider API to enable streaming chat completions with tool calling, multimodal input (images, PDFs), and thinking/reasoning support.
+
+## Build and Development Commands
+
+```bash
+# Install dependencies
+bun install
+
+# Compile TypeScript to JavaScript
+bun run compile
+
+# Watch mode for development (auto-recompile on changes)
+bun run watch
+
+# Run linter
+bun run lint
+
+# Format code with Prettier
+bun run format
+
+# Run all tests
+bun test
+
+# Bump version (updates package.json and CHANGELOG.md)
+bun run bump-version
+```
+
+## Development Workflow
+
+### Testing the Extension
+
+Press `F5` to launch the Extension Development Host with the extension loaded.
+
+### Running Tests
+
+Tests use the `@vscode/test-electron` framework. Run `bun test` to execute all tests, which compiles the project and runs the test suite.
+
+### Code Style
+
+- **Linting**: ESLint with TypeScript rules
+- **Formatting**: Prettier with tabs (width 2), semicolons, 120 character line width
+- **Pre-commit hooks**: Husky runs Prettier on staged files via lint-staged
+
+### Git Commit and PR Conventions
+
+- **DO NOT** add "Co-Authored-By: Codex" or similar attribution lines to commit messages
+- **DO NOT** add "Generated with Codex" or similar markers to pull request descriptions
+- Keep commit messages and PR descriptions clean and focused on the actual changes
+
+## Architecture
+
+### Core Components
+
+**`src/extension.ts`**: Extension activation and lifecycle
+- Registers the LiteLLM chat provider with vendor ID `"litellm"`
+- Implements the `litellm.manage` command for configuration UI
+- Manages status bar indicator showing connection state with 4 states:
+  - Not configured: `$(warning) LiteLLM`
+  - Loading: `$(loading~spin) LiteLLM`
+  - Connected: `$(check) LiteLLM (N)` where N is model count
+  - Error: `$(error) LiteLLM` with error details in tooltip
+- Creates "LiteLLM" output channel for diagnostic logging
+- Implements `litellm.testConnection` command to verify server connectivity
+- Implements `litellm.showDiagnostics` command to display configuration and connection status
+- Stores credentials securely in VS Code's SecretStorage (keys: `litellm.baseUrl`, `litellm.apiKey`)
+- Persists connection status in `globalState` across sessions
+
+**`src/provider.ts`**: Main provider implementation (`LiteLLMChatModelProvider`)
+- Implements VS Code's `LanguageModelChatProvider` interface
+- Fetches available models from LiteLLM's `/v1/model/info` endpoint (with fallback to `/v1/models`)
+- Handles streaming chat completions via `/v1/chat/completions`
+- Converts VS Code message format to OpenAI-compatible format
+- Parses streaming SSE responses and emits parts (text, tool calls, thinking/reasoning)
+- Manages tool call buffering and deduplication
+- Tracks prompt caching support per model from `/v1/model/info`
+- Captures extended model metadata (supports_response_schema, supports_reasoning, supports_pdf_input, supported_openai_params)
+- Broad model options pass-through: all `modelOptions` and `modelParameters` keys forwarded to LiteLLM except provider-owned fields (`model`, `messages`, `stream`, `stream_options`, `tools`, `tool_choice`)
+- Requests `stream_options: { include_usage: true }` by default and logs token usage from the final streaming chunk
+- Token estimation: text-only for the hard rejection path (no multimodal guesses); `provideTokenCount()` uses rough heuristics for images/PDFs for VS Code UI hints
+- Provides status callback mechanism to update extension about fetch results
+- Logs all operations to output channel for debugging
+- Shows notifications for:
+  - Missing configuration (one-time per session)
+  - Empty model list from server
+  - Connection errors with actionable buttons
+
+**`src/utils.ts`**: Conversion and validation utilities
+- `convertMessages()`: Transforms VS Code messages to OpenAI format, including multimodal content:
+  - `LanguageModelTextPart` → text content (string or text block)
+  - `LanguageModelDataPart` with image MIME (png/jpeg/gif/webp) → `image_url` content block with base64 data URL
+  - `LanguageModelDataPart` with `application/pdf` → `file` content block with base64 data URL
+  - `LanguageModelDataPart` with text/JSON MIME → decoded as text
+  - `LanguageModelPromptTsxPart` → text extraction
+  - Unknown binary MIME types → logged and skipped
+  - Preserves interleaved ordering of text/image/file parts
+  - User messages with non-text parts use array content format; text-only messages use string format
+- `convertTools()`: Transforms VS Code tool definitions to OpenAI function definitions
+  - `ToolMode.Required` with single tool → named function choice
+  - `ToolMode.Required` with multiple tools → `tool_choice: "required"` (no longer throws)
+- `sanitizeSchema()`: Sanitizes JSON schemas while preserving provider-compatible features:
+  - Preserves composite schemas (`anyOf`/`oneOf`/`allOf`) — recursively sanitizes branches instead of collapsing
+  - Preserves `$ref` and `definitions`/`$defs` for recursive schemas
+  - Preserves widely-supported keywords: `const`, `examples`, `title`, `exclusiveMinimum`/`exclusiveMaximum`, `minItems`/`maxItems`/`uniqueItems`
+  - Does NOT force `type: "object"` on nodes defined by composites or `$ref`
+  - Converts `number` → `integer` for ID-like property names
+- `validateRequest()`: Ensures correct tool call/result pairing in message sequences
+- `collectToolResultText()`: Handles text, `LanguageModelDataPart` (text/JSON decoded, image warned), and `LanguageModelPromptTsxPart` in tool results
+- `tryParseJSONObject()`: Safely parses JSON for tool call arguments
+
+**`src/types.ts`**: TypeScript interfaces for LiteLLM and OpenAI types
+- `OpenAIChatContentBlock`: Discriminated union of `OpenAIChatTextContentBlock`, `OpenAIChatImageUrlContentBlock`, and `OpenAIChatFileContentBlock`
+- `LiteLLMProvider`: Extended with `supports_response_schema`, `supports_reasoning`, `supports_pdf_input`, `supported_openai_params`
+- `LiteLLMModelInfoItem`: Extended with `supports_response_schema`, `supports_reasoning`, `supports_pdf_input`, `supports_audio_input`, `supports_audio_output`, `supported_openai_params`
+
+### Key Architectural Patterns
+
+**Model Registration with Provider Variants**
+
+The extension creates multiple model entries per LiteLLM model to support provider-specific routing:
+- `model-name:cheapest` - Routes to the cheapest available provider
+- `model-name:fastest` - Routes to the fastest available provider
+- `model-name:provider-name` - Routes to a specific provider (e.g., `gpt-4:openai` or `gpt-4:azure`)
+
+This allows users to choose routing strategy in the VS Code chat model picker.
+
+**Token Limit Management**
+
+Token constraints are resolved with the following priority:
+1. LiteLLM model info (from `/v1/models` response)
+2. Workspace settings (`litellm-vscode-chat.default*`)
+3. Hardcoded defaults (16K output, 128K context)
+
+The provider uses rough estimation (length/4) for token counting.
+
+**Model Parameters vs Capabilities**
+
+There are two distinct configuration concepts:
+- **Capabilities** (read from LiteLLM API): What the model CAN do (max tokens, context length, tool support, vision, reasoning, PDF input, etc.) - handled by `getTokenConstraints()` and extended metadata
+- **Parameters** (from user config or runtime): What we ASK the model to do (temperature, max_tokens, response_format, reasoning_effort, etc.) - handled by `getModelParameters()` and broad pass-through
+
+The `modelParameters` setting uses longest-prefix matching, so `"gpt-4"` matches `"gpt-4-turbo:openai"`.
+
+**Request Parameter Pass-through**
+
+The extension uses a broad pass-through approach for model parameters rather than an allow-list:
+- **Provider-owned fields** (never overwritable): `model`, `messages`, `stream`, `tools`, `tool_choice`
+- **Internal fields** (filtered): Keys starting with `_` are skipped (VS Code injects internal fields like `_capturingTokenCorrelationId` into `modelOptions`)
+- **Special handling**: `max_tokens` has its own precedence logic (runtime > config > default clamped to model max)
+- **Everything else**: All keys from `modelParameters` config and `options.modelOptions` runtime are forwarded directly to LiteLLM
+
+This enables any LiteLLM/OpenAI-compatible parameter without extension updates: `response_format`, `reasoning_effort`, `seed`, `top_k`, `parallel_tool_calls`, `logprobs`, `modalities`, `metadata`, etc.
+
+**Model Info and Prompt Caching**
+
+The provider fetches model metadata from LiteLLM's `/v1/model/info` endpoint:
+- **Fallback logic**: Tries `/v1/model/info` first, falls back to `/v1/models` on any error
+- **Model ID extraction**: Uses priority fallback (model_name → litellm_params.model → model_info.key → model_info.id)
+- **Prompt caching detection**: Tracks `supports_prompt_caching` flag per model
+- **Extended metadata**: Captures `supports_response_schema`, `supports_reasoning`, `supports_pdf_input`, `supported_openai_params` for diagnostics and future use
+- **Vision detection**: Sets `imageInput` capability from `supports_vision`; includes `pdf` in `input_modalities` from `supports_pdf_input`
+- **Cache management**: Only clears cache on successful fetch to preserve data on failure
+- **Cache control**: Adds `cache_control` blocks to system messages for supported models when enabled
+
+Prompt caching is controlled by `promptCaching.enabled` setting (default: true) and only affects models that advertise support.
+
+**Streaming Response Processing**
+
+The provider handles three formats for tool calls:
+1. **Standard OpenAI format**: Tool calls in `delta.tool_calls[]` array
+2. **Inline control tokens**: `<|tool_call_begin|>name<|tool_call_argument_begin|>{...}<|tool_call_end|>` embedded in text
+3. **Control token stripping**: Removes `<|*_section_begin|>` and `<|*_section_end|>` markers
+
+Tool calls are buffered until arguments become valid JSON, then emitted immediately to avoid perceived hanging. Deduplication prevents duplicate emissions.
+
+The provider handles thinking/reasoning tokens from multiple providers:
+- `choice.thinking` or `delta.thinking` — Anthropic Codex format (structured object with text/id/metadata)
+- `delta.reasoning_content` — DeepSeek, Kimi/Moonshot, xAI/Grok format (plain string)
+- `delta.reasoning` — other providers mapped through LiteLLM
+- All mapped to `LanguageModelThinkingPart` (probed dynamically, not yet in stable VS Code API)
+
+Structured `delta.content` arrays are handled: text blocks are extracted, non-text blocks silently ignored.
+
+Token usage from the final streaming chunk is logged to the output channel. The usage extraction runs before the `choices[0]` early-return to catch the common OpenAI `choices: []` + `usage: {...}` trailer format.
+
+**Configuration Storage**
+
+- Base URL and API key stored in VS Code's SecretStorage (encrypted)
+- Settings like token limits and model parameters stored in workspace/user settings
+- First-run welcome message shown once using `globalState`
+- Connection status persisted in `globalState` for status bar restoration
+
+**Diagnostics and Status Tracking**
+
+The extension implements comprehensive diagnostics to help users troubleshoot configuration issues:
+
+1. **Status Bar Indicator**: Shows real-time connection state
+   - Updates automatically when models are fetched
+   - Persists state across VS Code reloads
+   - Click to open diagnostics dialog
+
+2. **Output Channel**: Provides detailed logging
+   - All configuration changes logged with timestamps
+   - Model fetch attempts and results
+   - Full error messages with stack traces
+   - Network request/response information
+   - Located at "Output" panel → "LiteLLM" dropdown
+
+3. **Status Callback Pattern**: Provider notifies extension of fetch results
+   - `setStatusCallback()` method accepts callback function
+   - Provider calls callback with model count on success or error message on failure
+   - Extension updates status bar and persists state
+
+4. **User Notifications**: Proactive error reporting
+   - One-time notification when no configuration exists (silent mode only)
+   - Warning when server returns empty model list
+   - Error notifications with actionable buttons (Reconfigure, View Output)
+
+5. **Test Connection Command**: Proactive verification
+   - Manually trigger model fetch to test connectivity
+   - Shows detailed success/failure messages
+   - Updates status bar with results
+   - Provides access to output channel logs
+
+## Common Patterns
+
+### Adding a New Configuration Option
+
+1. Add the property to `package.json` under `contributes.configuration.properties`
+2. Read the value in `provider.ts` using `vscode.workspace.getConfiguration("litellm-vscode-chat")`
+3. Apply the configuration in the appropriate method (e.g., `provideLanguageModelChatResponse`)
+
+### Extending Tool Call Support
+
+Tool call handling is in `provider.ts`:
+- `processDelta()`: Processes incoming SSE chunks
+- `tryEmitBufferedToolCall()`: Emits tool calls when JSON is valid
+- `processTextContent()`: Handles inline control token parsing
+- `flushToolCallBuffers()`: Flushes all buffered calls on completion
+
+### Error Handling Strategy
+
+- **Model fetch fallback**: `/v1/model/info` errors (including non-404/405) gracefully fall back to `/v1/models`
+- **Network/certificate errors**: Provide specific actionable error messages
+- **Authentication failures (401)**: Prompt user to run "Manage LiteLLM Provider" command
+- **Silent mode errors**: Return empty array instead of throwing to prevent UI breakage
+- **Tool call JSON errors**: Throw on completion, silently drop on cancellation
+- **Logging consistency**: All errors logged through `this.log()` instead of `console.warn/error` for unified output
+
+## CI/CD Structure
+
+Workflows are organized with reusable workflow patterns:
+- **`bump-version-reusable.yml`**: Reusable workflow for version bumping
+- **`format-check-reusable.yml`**: Reusable workflow for Prettier format checking
+- **`test-reusable.yml`**: Reusable workflow for running tests
+- **`ci.yml`**: Main CI pipeline that calls reusable workflows
+- **`release.yml`**: Deploys to VS Code Marketplace on `deploy` branch push
+- **`auto-format.yml`**: Auto-formats and commits when PR has `auto-format` label
+
+Husky pre-commit hooks are disabled in CI using `CI=true` environment variable.
+
+## Testing Notes
+
+- Test file: `src/test/provider.test.ts`
+- Tests run in VS Code Extension Host environment
+- Use `@vscode/test-electron` for extension testing

--- a/README.md
+++ b/README.md
@@ -87,7 +87,22 @@ Override default request parameters for specific models using the `modelParamete
 - `seed` - Deterministic output
 - And any other parameter supported by your LiteLLM and model provider backend
 
-All `modelParameters` keys are passed through to LiteLLM — the extension does not filter or restrict which parameters you can set.
+All `modelParameters` keys are passed through to LiteLLM — the extension does not filter or restrict which parameters you can set. The reserved key `_replaceDefaults` is extension metadata and is never forwarded.
+
+**Built-in defaults**: The extension applies `temperature: 0.7` by default. Some models (e.g., `gpt-5.5`) have built-in overrides that suppress the default temperature. User `modelParameters` entries merge on top of these defaults.
+
+**`_replaceDefaults`**: Set `"_replaceDefaults": true` in a model entry to skip all built-in defaults for that model and use only your supplied parameters:
+
+```json
+{
+  "litellm-vscode-chat.modelParameters": {
+    "gpt-4": {
+      "_replaceDefaults": true,
+      "top_p": 0.9
+    }
+  }
+}
+```
 
 **Prefix matching**: Configuration keys use longest prefix matching. For example, `"gpt-4"` will match `"gpt-4-turbo:openai"`, `"gpt-4:azure"`, etc. More specific keys take precedence.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ All `modelParameters` keys are passed through to LiteLLM — the extension does 
 
 **Built-in defaults**: The extension applies `temperature: 0.7` by default. Some models (e.g., `gpt-5.5`) have built-in overrides that suppress the default temperature. User `modelParameters` entries merge on top of these defaults.
 
-**`_replaceDefaults`**: Set `"_replaceDefaults": true` in a model entry to skip all built-in defaults for that model and use only your supplied parameters:
+**`_replaceDefaults`**: Set `"_replaceDefaults": true` in a model entry to skip built-in request-parameter defaults for that model (for example, the default `temperature`) and use only the request parameters you supply from configuration:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"type": "git",
 		"url": "https://github.com/Vivswan/litellm-vscode-chat"
 	},
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"engines": {
 		"vscode": "^1.110.0"
 	},

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 				"litellm-vscode-chat.modelParameters": {
 					"type": "object",
 					"default": {},
-					"description": "Model-specific request parameters to customize API behavior. Supports max_tokens, temperature, top_p, frequency_penalty, presence_penalty, stop, etc. Uses longest prefix matching (e.g., 'gpt-4' matches 'gpt-4-turbo:openai').",
+					"description": "Model-specific request parameters to customize API behavior. Supports max_tokens, temperature, top_p, frequency_penalty, presence_penalty, stop, etc. Uses longest prefix matching (e.g., 'gpt-4' matches 'gpt-4-turbo:openai'). Set '_replaceDefaults: true' in a model entry to skip built-in codebase defaults (e.g., temperature) for that model. Note: gpt-5.5 has no built-in default temperature.",
 					"additionalProperties": {
 						"type": "object"
 					}

--- a/src/modelDefaults.ts
+++ b/src/modelDefaults.ts
@@ -1,0 +1,27 @@
+export type ModelDefaultsMap = Record<string, Record<string, unknown>>;
+
+const FALLBACK_DEFAULTS: Record<string, unknown> = { temperature: 0.7 };
+
+const MODEL_OVERRIDES: ModelDefaultsMap = {
+	"gpt-5.5": {},
+};
+
+export function findLongestPrefixMatch<T>(id: string, entries: Record<string, T>): T | undefined {
+	let best: { key: string; value: T } | undefined;
+	for (const [key, value] of Object.entries(entries)) {
+		if (id === key || id.startsWith(key)) {
+			if (!best || key.length > best.key.length) {
+				best = { key, value };
+			}
+		}
+	}
+	return best?.value;
+}
+
+export function getModelDefaults(modelId: string): Record<string, unknown> {
+	const override = findLongestPrefixMatch(modelId, MODEL_OVERRIDES);
+	if (override !== undefined) {
+		return { ...override };
+	}
+	return { ...FALLBACK_DEFAULTS };
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -16,6 +16,7 @@ import type {
 	LiteLLMModelsResponse,
 	LiteLLMProvider,
 } from "./types";
+import { findLongestPrefixMatch, getModelDefaults } from "./modelDefaults";
 
 import { convertTools, convertMessages, tryParseJSONObject, validateRequest } from "./utils";
 
@@ -191,19 +192,8 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	private getModelParameters(modelId: string): Record<string, unknown> {
 		const config = vscode.workspace.getConfiguration("litellm-vscode-chat");
 		const modelParameters = config.get<Record<string, Record<string, unknown>>>("modelParameters", {});
-
-		// Find longest matching prefix
-		let longestMatch: { key: string; value: Record<string, unknown> } | undefined;
-
-		for (const [key, value] of Object.entries(modelParameters)) {
-			if (modelId === key || modelId.startsWith(key)) {
-				if (!longestMatch || key.length > longestMatch.key.length) {
-					longestMatch = { key, value };
-				}
-			}
-		}
-
-		return longestMatch ? { ...longestMatch.value } : {};
+		const match = findLongestPrefixMatch(modelId, modelParameters);
+		return match ? { ...match } : {};
 	}
 
 	/**
@@ -744,14 +734,19 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 				maxTokens = Math.min(4096, model.maxOutputTokens);
 			}
 
-			// Build base request body
+			// Build base request body with codebase defaults
+			const replaceDefaults = modelParams._replaceDefaults === true;
+			delete modelParams._replaceDefaults;
+
+			const defaults = replaceDefaults ? {} : getModelDefaults(model.id);
+
 			requestBody = {
 				model: model.id,
 				messages: openaiMessages,
 				stream: true,
 				stream_options: { include_usage: true },
 				max_tokens: maxTokens,
-				temperature: 0.7, // Base default
+				...defaults,
 			};
 
 			// Provider-owned fields that cannot be overwritten by config or runtime options

--- a/src/test/host-fidelity.test.ts
+++ b/src/test/host-fidelity.test.ts
@@ -141,6 +141,21 @@ suite("Host-Fidelity Tests (capture)", function () {
 		return { body, parts };
 	}
 
+	/** Temporarily set modelParameters config for a single test and restore it afterward. */
+	async function withModelParameters<T>(
+		value: Record<string, Record<string, unknown>>,
+		fn: () => Promise<T>
+	): Promise<T> {
+		const config = vscode.workspace.getConfiguration("litellm-vscode-chat");
+		const original = config.inspect<Record<string, Record<string, unknown>>>("modelParameters")?.globalValue;
+		await config.update("modelParameters", value, vscode.ConfigurationTarget.Global);
+		try {
+			return await fn();
+		} finally {
+			await config.update("modelParameters", original, vscode.ConfigurationTarget.Global);
+		}
+	}
+
 	// ─── Model Discovery ─────────────────────────────────────────────────
 
 	suite("model discovery", () => {
@@ -254,6 +269,24 @@ suite("Host-Fidelity Tests (capture)", function () {
 			const { body } = await sendAndCapture([vscode.LanguageModelChatMessage.User("hi")]);
 			assert.ok(typeof body.model === "string", "model should be a string");
 			assert.ok(typeof body.max_tokens === "number", "max_tokens should be a number");
+		});
+
+		test("modelParameters merge onto built-in defaults through the host path", async () => {
+			await withModelParameters({ [model.id]: { top_p: 0.9 } }, async () => {
+				const { body } = await sendAndCapture([vscode.LanguageModelChatMessage.User("hi")]);
+				assert.strictEqual(body.temperature, 0.7, "Built-in default temperature should still be present");
+				assert.strictEqual(body.top_p, 0.9, "Configured parameter should be merged into the request");
+				assert.strictEqual(body._replaceDefaults, undefined, "Extension metadata must not leak into the request");
+			});
+		});
+
+		test("_replaceDefaults skips built-in defaults through the host path", async () => {
+			await withModelParameters({ [model.id]: { _replaceDefaults: true, top_p: 0.9 } }, async () => {
+				const { body } = await sendAndCapture([vscode.LanguageModelChatMessage.User("hi")]);
+				assert.strictEqual(body.temperature, undefined, "Built-in temperature should be omitted when replacing");
+				assert.strictEqual(body.top_p, 0.9, "Configured parameter should still be forwarded");
+				assert.strictEqual(body._replaceDefaults, undefined, "Extension metadata must not leak into the request");
+			});
 		});
 
 		test("multi-turn conversation preserves all message roles and order", async () => {

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { LiteLLMChatModelProvider } from "../provider";
 import { convertMessages, convertTools, validateRequest, tryParseJSONObject } from "../utils";
+import { findLongestPrefixMatch, getModelDefaults } from "../modelDefaults";
 
 interface OpenAIToolCall {
 	id: string;
@@ -1081,6 +1082,226 @@ suite("LiteLLM Chat Provider Extension", () => {
 					"Should include stream_options by default"
 				);
 			});
+			test("unmatched model gets built-in fallback defaults (temperature 0.7)", async () => {
+				const originalFetch = global.fetch;
+				const originalGetConfig = vscode.workspace.getConfiguration;
+				let capturedBody: Record<string, unknown> | undefined;
+
+				global.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+					capturedBody = JSON.parse(init?.body as string);
+					return { ok: true, body: sseStream("ok") } as unknown as Response;
+				};
+
+				vscode.workspace.getConfiguration = ((section?: string) => {
+					if (section === "litellm-vscode-chat") {
+						return {
+							get: (key: string) => {
+								if (key === "modelParameters") {
+									return {};
+								}
+								return undefined;
+							},
+						};
+					}
+					return originalGetConfig(section!);
+				}) as typeof vscode.workspace.getConfiguration;
+
+				try {
+					const provider = createConfiguredProvider();
+					await provider.prepareLanguageModelChatInformation(
+						{ silent: true },
+						new vscode.CancellationTokenSource().token
+					);
+					await provider.provideLanguageModelChatResponse(
+						modelInfo,
+						[
+							{
+								role: vscode.LanguageModelChatMessageRole.User,
+								content: [new vscode.LanguageModelTextPart("test")],
+								name: undefined,
+							},
+						],
+						{
+							toolMode: vscode.LanguageModelChatToolMode.Auto,
+						} as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+						{ report: () => {} },
+						new vscode.CancellationTokenSource().token
+					);
+					assert.ok(capturedBody, "Should have captured request body");
+					assert.strictEqual(capturedBody!.temperature, 0.7, "Should include default temperature 0.7");
+				} finally {
+					global.fetch = originalFetch;
+					vscode.workspace.getConfiguration = originalGetConfig;
+				}
+			});
+
+			test("gpt-5.5 model gets no built-in temperature", async () => {
+				const originalFetch = global.fetch;
+				const originalGetConfig = vscode.workspace.getConfiguration;
+				let capturedBody: Record<string, unknown> | undefined;
+
+				global.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+					capturedBody = JSON.parse(init?.body as string);
+					return { ok: true, body: sseStream("ok") } as unknown as Response;
+				};
+
+				vscode.workspace.getConfiguration = ((section?: string) => {
+					if (section === "litellm-vscode-chat") {
+						return {
+							get: (key: string) => {
+								if (key === "modelParameters") {
+									return {};
+								}
+								return undefined;
+							},
+						};
+					}
+					return originalGetConfig(section!);
+				}) as typeof vscode.workspace.getConfiguration;
+
+				const gpt55Model = { ...modelInfo, id: "gpt-5.5:openai" };
+
+				try {
+					const provider = createConfiguredProvider();
+					await provider.prepareLanguageModelChatInformation(
+						{ silent: true },
+						new vscode.CancellationTokenSource().token
+					);
+					await provider.provideLanguageModelChatResponse(
+						gpt55Model,
+						[
+							{
+								role: vscode.LanguageModelChatMessageRole.User,
+								content: [new vscode.LanguageModelTextPart("test")],
+								name: undefined,
+							},
+						],
+						{
+							toolMode: vscode.LanguageModelChatToolMode.Auto,
+						} as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+						{ report: () => {} },
+						new vscode.CancellationTokenSource().token
+					);
+					assert.ok(capturedBody, "Should have captured request body");
+					assert.strictEqual(capturedBody!.temperature, undefined, "gpt-5.5 should not have temperature");
+				} finally {
+					global.fetch = originalFetch;
+					vscode.workspace.getConfiguration = originalGetConfig;
+				}
+			});
+
+			test("_replaceDefaults: true skips codebase defaults", async () => {
+				const originalFetch = global.fetch;
+				const originalGetConfig = vscode.workspace.getConfiguration;
+				let capturedBody: Record<string, unknown> | undefined;
+
+				global.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+					capturedBody = JSON.parse(init?.body as string);
+					return { ok: true, body: sseStream("ok") } as unknown as Response;
+				};
+
+				vscode.workspace.getConfiguration = ((section?: string) => {
+					if (section === "litellm-vscode-chat") {
+						return {
+							get: (key: string) => {
+								if (key === "modelParameters") {
+									return { "test-model": { _replaceDefaults: true, top_p: 0.9 } };
+								}
+								return undefined;
+							},
+						};
+					}
+					return originalGetConfig(section!);
+				}) as typeof vscode.workspace.getConfiguration;
+
+				try {
+					const provider = createConfiguredProvider();
+					await provider.prepareLanguageModelChatInformation(
+						{ silent: true },
+						new vscode.CancellationTokenSource().token
+					);
+					await provider.provideLanguageModelChatResponse(
+						modelInfo,
+						[
+							{
+								role: vscode.LanguageModelChatMessageRole.User,
+								content: [new vscode.LanguageModelTextPart("test")],
+								name: undefined,
+							},
+						],
+						{
+							toolMode: vscode.LanguageModelChatToolMode.Auto,
+						} as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+						{ report: () => {} },
+						new vscode.CancellationTokenSource().token
+					);
+					assert.ok(capturedBody, "Should have captured request body");
+					assert.strictEqual(
+						capturedBody!.temperature,
+						undefined,
+						"Should not have default temperature when _replaceDefaults is true"
+					);
+					assert.strictEqual(capturedBody!.top_p, 0.9, "Should have user-specified top_p");
+					assert.strictEqual(capturedBody!._replaceDefaults, undefined, "_replaceDefaults must not appear in request");
+				} finally {
+					global.fetch = originalFetch;
+					vscode.workspace.getConfiguration = originalGetConfig;
+				}
+			});
+
+			test("user config without _replaceDefaults merges onto codebase defaults", async () => {
+				const originalFetch = global.fetch;
+				const originalGetConfig = vscode.workspace.getConfiguration;
+				let capturedBody: Record<string, unknown> | undefined;
+
+				global.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+					capturedBody = JSON.parse(init?.body as string);
+					return { ok: true, body: sseStream("ok") } as unknown as Response;
+				};
+
+				vscode.workspace.getConfiguration = ((section?: string) => {
+					if (section === "litellm-vscode-chat") {
+						return {
+							get: (key: string) => {
+								if (key === "modelParameters") {
+									return { "test-model": { top_p: 0.8 } };
+								}
+								return undefined;
+							},
+						};
+					}
+					return originalGetConfig(section!);
+				}) as typeof vscode.workspace.getConfiguration;
+
+				try {
+					const provider = createConfiguredProvider();
+					await provider.prepareLanguageModelChatInformation(
+						{ silent: true },
+						new vscode.CancellationTokenSource().token
+					);
+					await provider.provideLanguageModelChatResponse(
+						modelInfo,
+						[
+							{
+								role: vscode.LanguageModelChatMessageRole.User,
+								content: [new vscode.LanguageModelTextPart("test")],
+								name: undefined,
+							},
+						],
+						{
+							toolMode: vscode.LanguageModelChatToolMode.Auto,
+						} as unknown as vscode.ProvideLanguageModelChatResponseOptions,
+						{ report: () => {} },
+						new vscode.CancellationTokenSource().token
+					);
+					assert.ok(capturedBody, "Should have captured request body");
+					assert.strictEqual(capturedBody!.temperature, 0.7, "Should keep default temperature when merging");
+					assert.strictEqual(capturedBody!.top_p, 0.8, "Should have user-specified top_p");
+				} finally {
+					global.fetch = originalFetch;
+					vscode.workspace.getConfiguration = originalGetConfig;
+				}
+			});
 		});
 
 		suite("diagnostics", () => {
@@ -2125,6 +2346,34 @@ suite("LiteLLM Chat Provider Extension", () => {
 			) as vscode.LanguageModelToolCallPart;
 			assert.ok(toolPart, "Should emit a tool call from inline control tokens");
 			assert.equal(toolPart.name, "my_tool");
+		});
+	});
+
+	suite("modelDefaults", () => {
+		test("findLongestPrefixMatch returns longest match", () => {
+			const entries = { gpt: "a", "gpt-4": "b", "gpt-4-turbo": "c" };
+			assert.strictEqual(findLongestPrefixMatch("gpt-4-turbo:fastest", entries), "c");
+			assert.strictEqual(findLongestPrefixMatch("gpt-4:openai", entries), "b");
+			assert.strictEqual(findLongestPrefixMatch("gpt-3.5", entries), "a");
+		});
+
+		test("findLongestPrefixMatch returns undefined for no match", () => {
+			assert.strictEqual(findLongestPrefixMatch("claude-3", { gpt: "a" }), undefined);
+		});
+
+		test("getModelDefaults returns temperature 0.7 for unmatched model", () => {
+			const defaults = getModelDefaults("claude-3-opus");
+			assert.strictEqual(defaults.temperature, 0.7);
+		});
+
+		test("getModelDefaults returns no temperature for gpt-5.5", () => {
+			const defaults = getModelDefaults("gpt-5.5");
+			assert.strictEqual(defaults.temperature, undefined);
+		});
+
+		test("getModelDefaults returns no temperature for gpt-5.5 with suffix", () => {
+			const defaults = getModelDefaults("gpt-5.5:openai");
+			assert.strictEqual(defaults.temperature, undefined);
 		});
 	});
 });

--- a/src/vscode.d.ts
+++ b/src/vscode.d.ts
@@ -130,7 +130,7 @@ declare module 'vscode' {
 		 * 'iso88597', 'windows1255', 'iso88598', 'iso885910', 'iso885916', 'windows1254',
 		 * 'iso88599', 'windows1258', 'gbk', 'gb18030', 'cp950', 'big5hkscs', 'shiftjis',
 		 * 'eucjp', 'euckr', 'windows874', 'iso885911', 'koi8ru', 'koi8t', 'gb2312',
-		 * 'cp865', 'cp850'.
+		 * 'cp865', 'cp850', 'cp857'.
 		 */
 		readonly encoding: string;
 


### PR DESCRIPTION
This pull request introduces support for built-in and model-specific default request parameters, including a mechanism to override or skip these defaults using a reserved `_replaceDefaults` key in the `modelParameters` configuration. It also improves documentation and test coverage for this behavior, ensuring that extension metadata is not forwarded to the API and that merging and override logic is well-defined.

**Model parameter defaults and override support:**

* Added `src/modelDefaults.ts` to define built-in request parameter defaults (e.g., `temperature: 0.7`) and per-model overrides (e.g., no default temperature for `gpt-5.5`). Introduced `findLongestPrefixMatch()` and `getModelDefaults()` utilities to support longest-prefix matching and default retrieval.
* Updated `src/provider.ts` to merge user-configured `modelParameters` on top of built-in defaults unless `_replaceDefaults: true` is set, in which case only user-supplied parameters are used. The reserved `_replaceDefaults` key is stripped before sending requests. [[1]](diffhunk://#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3L194-R196) [[2]](diffhunk://#diff-e0e6d91455eef50c5793e300039e5cdc7e6d372707172b639564495e4fa0a2f3L747-R749)
* Updated the `package.json` configuration description for `modelParameters` to document the `_replaceDefaults` behavior and clarify built-in defaults.
* Amended the `README.md` to document the new merging and override logic, including usage examples for `_replaceDefaults` and notes about built-in defaults.

**Documentation and testing improvements:**

* Added a comprehensive `AGENTS.md` file documenting project architecture, configuration, and key implementation details for contributors.
* Enhanced test coverage in `src/test/host-fidelity.test.ts` to verify correct merging of built-in defaults, user parameters, and override behavior, and to ensure extension metadata is not included in requests. [[1]](diffhunk://#diff-d76d90fb0146e302224891e714b5c428d4197ec07e906e888a66aafbba477989R144-R158) [[2]](diffhunk://#diff-d76d90fb0146e302224891e714b5c428d4197ec07e906e888a66aafbba477989R274-R291)

**Other changes:**

* Bumped extension version to `0.2.2` in `package.json`.
* Removed the obsolete `AGENT.md` file.