### PR TITLE
feat: model capability overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 				"litellm-vscode-chat.modelCapabilitiesOverrides": {
 					"type": "object",
 					"default": {},
-					"description": "Override model capabilities. Key is model ID (prefix-matched), value is comma-separated capabilities to ENABLE: 'toolCalling', 'imageInput'. Example: { \"my-model\": \"toolCalling,imageInput\" }",
+					"description": "Override model capabilities. Key is model ID (prefix-matched), value is comma-separated capabilities to ENABLE: 'toolCalling', 'imageInput'. For multi-server setups, prefix with server label (e.g., 'Production/gpt-4'). Server-scoped keys take priority. Example: { \"my-model\": \"toolCalling,imageInput\" }",
 					"additionalProperties": {
 						"type": "string"
 					}

--- a/package.json
+++ b/package.json
@@ -108,6 +108,14 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Mask the API key input field when configuring. Disable to see the key as you type."
+				},
+				"litellm-vscode-chat.modelCapabilitiesOverrides": {
+					"type": "object",
+					"default": {},
+					"description": "Override model capabilities. Key is model ID (prefix-matched), value is comma-separated capabilities to ENABLE: 'toolCalling', 'imageInput'. Example: { \"my-model\": \"toolCalling,imageInput\" }",
+					"additionalProperties": {
+						"type": "string"
+					}
 				}
 			}
 		}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -32,12 +32,27 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	private _modelRoutes = new Map<string, ModelRoute>();
 	private _getServers?: () => Promise<ServerWithKey[]>;
 
+	private readonly _onDidChange = new vscode.EventEmitter<void>();
+	readonly onDidChangeLanguageModelChatInformation = this._onDidChange.event;
+	private readonly _configWatcher: vscode.Disposable;
+
 	constructor(
 		private readonly secrets: vscode.SecretStorage,
 		private readonly userAgent: string,
 		private readonly outputChannel?: vscode.OutputChannel,
 		private readonly issueReporter?: IssueReporter
-	) {}
+	) {
+		this._configWatcher = vscode.workspace.onDidChangeConfiguration((e) => {
+			if (e.affectsConfiguration("litellm-vscode-chat.modelCapabilitiesOverrides")) {
+				this._onDidChange.fire();
+			}
+		});
+	}
+
+	dispose(): void {
+		this._configWatcher.dispose();
+		this._onDidChange.dispose();
+	}
 
 	setStatusCallback(callback: (status: AggregatedStatus) => void): void {
 		this._statusCallback = callback;

--- a/src/provider/registration.ts
+++ b/src/provider/registration.ts
@@ -1,8 +1,10 @@
+import * as vscode from "vscode";
 import { LanguageModelChatInformation } from "vscode";
 import type { LiteLLMModelItem } from "../types";
 import type { ServerWithKey } from "../extension/serverRegistry";
 import type { ModelRoute } from "./request";
 import { getTokenConstraints, buildExposedModelId } from "./request";
+import { findLongestPrefixMatch } from "./modelDefaults";
 
 export interface RegistrationResult {
 	infos: LanguageModelChatInformation[];
@@ -18,6 +20,9 @@ export function buildModelInfos(
 ): RegistrationResult {
 	const routes = new Map<string, ModelRoute>();
 	const promptCaching = new Map<string, boolean>();
+	const capOverrides = vscode.workspace
+		.getConfiguration("litellm-vscode-chat")
+		.get<Record<string, string>>("modelCapabilitiesOverrides", {});
 
 	const registerRoute = (exposedId: string, rawId: string) => {
 		routes.set(exposedId, {
@@ -50,10 +55,10 @@ export function buildModelInfos(
 					version: "1.0.0",
 					maxInputTokens: constraints.maxInputTokens,
 					maxOutputTokens: constraints.maxOutputTokens,
-					capabilities: {
+					capabilities: applyCapabilityOverrides(m.id, {
 						toolCalling: providers[0].supports_tools !== false,
 						imageInput: vision,
-					},
+					}, capOverrides),
 				} satisfies LanguageModelChatInformation,
 			];
 		}
@@ -73,10 +78,10 @@ export function buildModelInfos(
 					version: "1.0.0",
 					maxInputTokens: constraints.maxInputTokens,
 					maxOutputTokens: constraints.maxOutputTokens,
-					capabilities: {
+					capabilities: applyCapabilityOverrides(m.id, {
 						toolCalling: true,
 						imageInput: vision,
-					},
+					}, capOverrides),
 				} satisfies LanguageModelChatInformation,
 			];
 		}
@@ -90,10 +95,10 @@ export function buildModelInfos(
 			const maxOutput = Math.min(...providerConstraints.map((c) => c.maxOutputTokens));
 			const maxInput = Math.max(1, aggregateContextLen - maxOutput);
 			const aggregatePromptCaching = toolProviders.every((p) => p.supports_prompt_caching === true);
-			const aggregateCapabilities = {
+			const aggregateCapabilities = applyCapabilityOverrides(m.id, {
 				toolCalling: true,
 				imageInput: vision,
-			};
+			}, capOverrides);
 
 			const cheapestRaw = `${m.id}:cheapest`;
 			const fastestRaw = `${m.id}:fastest`;
@@ -142,10 +147,10 @@ export function buildModelInfos(
 				version: "1.0.0",
 				maxInputTokens: constraints.maxInputTokens,
 				maxOutputTokens: constraints.maxOutputTokens,
-				capabilities: {
+				capabilities: applyCapabilityOverrides(m.id, {
 					toolCalling: true,
 					imageInput: vision,
-				},
+				}, capOverrides),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, p.supports_prompt_caching === true);
 			registerRoute(exposedId, rawId);
@@ -164,10 +169,10 @@ export function buildModelInfos(
 				version: "1.0.0",
 				maxInputTokens: constraints.maxInputTokens,
 				maxOutputTokens: constraints.maxOutputTokens,
-				capabilities: {
+				capabilities: applyCapabilityOverrides(m.id, {
 					toolCalling: false,
 					imageInput: vision,
-				},
+				}, capOverrides),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, base.supports_prompt_caching === true);
 			registerRoute(exposedId, m.id);
@@ -177,4 +182,18 @@ export function buildModelInfos(
 	});
 
 	return { infos, routes, promptCaching };
+}
+
+export function applyCapabilityOverrides(
+	modelId: string,
+	capabilities: { toolCalling: boolean; imageInput: boolean },
+	overrides: Record<string, string>
+): { toolCalling: boolean; imageInput: boolean } {
+	const match = findLongestPrefixMatch(modelId, overrides);
+	if (!match) return capabilities;
+	const caps = match.split(",").map((s) => s.trim());
+	return {
+		toolCalling: caps.includes("toolCalling") ? true : capabilities.toolCalling,
+		imageInput: caps.includes("imageInput") ? true : capabilities.imageInput,
+	};
 }

--- a/src/provider/registration.ts
+++ b/src/provider/registration.ts
@@ -58,7 +58,7 @@ export function buildModelInfos(
 					capabilities: applyCapabilityOverrides(m.id, {
 						toolCalling: providers[0].supports_tools !== false,
 						imageInput: vision,
-					}, capOverrides),
+					}, capOverrides, server.label),
 				} satisfies LanguageModelChatInformation,
 			];
 		}
@@ -81,7 +81,7 @@ export function buildModelInfos(
 					capabilities: applyCapabilityOverrides(m.id, {
 						toolCalling: true,
 						imageInput: vision,
-					}, capOverrides),
+					}, capOverrides, server.label),
 				} satisfies LanguageModelChatInformation,
 			];
 		}
@@ -150,7 +150,7 @@ export function buildModelInfos(
 				capabilities: applyCapabilityOverrides(m.id, {
 					toolCalling: true,
 					imageInput: vision,
-				}, capOverrides),
+				}, capOverrides, server.label),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, p.supports_prompt_caching === true);
 			registerRoute(exposedId, rawId);
@@ -172,7 +172,7 @@ export function buildModelInfos(
 				capabilities: applyCapabilityOverrides(m.id, {
 					toolCalling: false,
 					imageInput: vision,
-				}, capOverrides),
+				}, capOverrides, server.label),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, base.supports_prompt_caching === true);
 			registerRoute(exposedId, m.id);
@@ -187,11 +187,23 @@ export function buildModelInfos(
 export function applyCapabilityOverrides(
 	modelId: string,
 	capabilities: { toolCalling: boolean; imageInput: boolean },
-	overrides: Record<string, string>
+	overrides: Record<string, string>,
+	serverLabel?: string
 ): { toolCalling: boolean; imageInput: boolean } {
-	const match = findLongestPrefixMatch(modelId, overrides);
-	if (!match) return capabilities;
-	const caps = match.split(",").map((s) => s.trim());
+	const VALID_CAPS = ["toolCalling", "imageInput"];
+	let matchValue: string | undefined;
+	if (serverLabel) {
+		matchValue = findLongestPrefixMatch(`${serverLabel}/${modelId}`, overrides);
+	}
+	if (!matchValue) {
+		matchValue = findLongestPrefixMatch(modelId, overrides);
+	}
+	if (!matchValue) return capabilities;
+	const caps = matchValue.split(",").map((s) => s.trim());
+	const unknown = caps.filter((c) => c !== "" && !VALID_CAPS.includes(c));
+	if (unknown.length > 0) {
+		console.warn(`[LiteLLM] Unknown capability overrides for "${modelId}": ${unknown.join(", ")}. Valid values: ${VALID_CAPS.join(", ")}`);
+	}
 	return {
 		toolCalling: caps.includes("toolCalling") ? true : capabilities.toolCalling,
 		imageInput: caps.includes("imageInput") ? true : capabilities.imageInput,

--- a/src/provider/registration.ts
+++ b/src/provider/registration.ts
@@ -55,10 +55,15 @@ export function buildModelInfos(
 					version: "1.0.0",
 					maxInputTokens: constraints.maxInputTokens,
 					maxOutputTokens: constraints.maxOutputTokens,
-					capabilities: applyCapabilityOverrides(m.id, {
-						toolCalling: providers[0].supports_tools !== false,
-						imageInput: vision,
-					}, capOverrides, server.label),
+					capabilities: applyCapabilityOverrides(
+						m.id,
+						{
+							toolCalling: providers[0].supports_tools !== false,
+							imageInput: vision,
+						},
+						capOverrides,
+						server.label
+					),
 				} satisfies LanguageModelChatInformation,
 			];
 		}
@@ -78,10 +83,15 @@ export function buildModelInfos(
 					version: "1.0.0",
 					maxInputTokens: constraints.maxInputTokens,
 					maxOutputTokens: constraints.maxOutputTokens,
-					capabilities: applyCapabilityOverrides(m.id, {
-						toolCalling: true,
-						imageInput: vision,
-					}, capOverrides, server.label),
+					capabilities: applyCapabilityOverrides(
+						m.id,
+						{
+							toolCalling: true,
+							imageInput: vision,
+						},
+						capOverrides,
+						server.label
+					),
 				} satisfies LanguageModelChatInformation,
 			];
 		}
@@ -95,10 +105,15 @@ export function buildModelInfos(
 			const maxOutput = Math.min(...providerConstraints.map((c) => c.maxOutputTokens));
 			const maxInput = Math.max(1, aggregateContextLen - maxOutput);
 			const aggregatePromptCaching = toolProviders.every((p) => p.supports_prompt_caching === true);
-			const aggregateCapabilities = applyCapabilityOverrides(m.id, {
-				toolCalling: true,
-				imageInput: vision,
-			}, capOverrides);
+			const aggregateCapabilities = applyCapabilityOverrides(
+				m.id,
+				{
+					toolCalling: true,
+					imageInput: vision,
+				},
+				capOverrides,
+				server.label
+			);
 
 			const cheapestRaw = `${m.id}:cheapest`;
 			const fastestRaw = `${m.id}:fastest`;
@@ -147,10 +162,15 @@ export function buildModelInfos(
 				version: "1.0.0",
 				maxInputTokens: constraints.maxInputTokens,
 				maxOutputTokens: constraints.maxOutputTokens,
-				capabilities: applyCapabilityOverrides(m.id, {
-					toolCalling: true,
-					imageInput: vision,
-				}, capOverrides, server.label),
+				capabilities: applyCapabilityOverrides(
+					m.id,
+					{
+						toolCalling: true,
+						imageInput: vision,
+					},
+					capOverrides,
+					server.label
+				),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, p.supports_prompt_caching === true);
 			registerRoute(exposedId, rawId);
@@ -169,10 +189,15 @@ export function buildModelInfos(
 				version: "1.0.0",
 				maxInputTokens: constraints.maxInputTokens,
 				maxOutputTokens: constraints.maxOutputTokens,
-				capabilities: applyCapabilityOverrides(m.id, {
-					toolCalling: false,
-					imageInput: vision,
-				}, capOverrides, server.label),
+				capabilities: applyCapabilityOverrides(
+					m.id,
+					{
+						toolCalling: false,
+						imageInput: vision,
+					},
+					capOverrides,
+					server.label
+				),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, base.supports_prompt_caching === true);
 			registerRoute(exposedId, m.id);
@@ -202,7 +227,9 @@ export function applyCapabilityOverrides(
 	const caps = matchValue.split(",").map((s) => s.trim());
 	const unknown = caps.filter((c) => c !== "" && !VALID_CAPS.includes(c));
 	if (unknown.length > 0) {
-		console.warn(`[LiteLLM] Unknown capability overrides for "${modelId}": ${unknown.join(", ")}. Valid values: ${VALID_CAPS.join(", ")}`);
+		console.warn(
+			`[LiteLLM] Unknown capability overrides for "${modelId}": ${unknown.join(", ")}. Valid values: ${VALID_CAPS.join(", ")}`
+		);
 	}
 	return {
 		toolCalling: caps.includes("toolCalling") ? true : capabilities.toolCalling,

--- a/src/provider/registration.ts
+++ b/src/provider/registration.ts
@@ -62,7 +62,8 @@ export function buildModelInfos(
 							imageInput: vision,
 						},
 						capOverrides,
-						server.label
+						server.label,
+						log
 					),
 				} satisfies LanguageModelChatInformation,
 			];
@@ -90,7 +91,8 @@ export function buildModelInfos(
 							imageInput: vision,
 						},
 						capOverrides,
-						server.label
+						server.label,
+						log
 					),
 				} satisfies LanguageModelChatInformation,
 			];
@@ -112,7 +114,8 @@ export function buildModelInfos(
 					imageInput: vision,
 				},
 				capOverrides,
-				server.label
+				server.label,
+				log
 			);
 
 			const cheapestRaw = `${m.id}:cheapest`;
@@ -169,7 +172,8 @@ export function buildModelInfos(
 						imageInput: vision,
 					},
 					capOverrides,
-					server.label
+					server.label,
+					log
 				),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, p.supports_prompt_caching === true);
@@ -196,7 +200,8 @@ export function buildModelInfos(
 						imageInput: vision,
 					},
 					capOverrides,
-					server.label
+					server.label,
+					log
 				),
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, base.supports_prompt_caching === true);
@@ -213,12 +218,19 @@ export function applyCapabilityOverrides(
 	modelId: string,
 	capabilities: { toolCalling: boolean; imageInput: boolean },
 	overrides: Record<string, string>,
-	serverLabel?: string
+	serverLabel?: string,
+	log?: (message: string) => void
 ): { toolCalling: boolean; imageInput: boolean } {
 	const VALID_CAPS = ["toolCalling", "imageInput"];
 	let matchValue: string | undefined;
 	if (serverLabel) {
-		matchValue = findLongestPrefixMatch(`${serverLabel}/${modelId}`, overrides);
+		const scopedOverrides: Record<string, string> = {};
+		for (const [key, value] of Object.entries(overrides)) {
+			if (key.includes("/")) {
+				scopedOverrides[key] = value;
+			}
+		}
+		matchValue = findLongestPrefixMatch(`${serverLabel}/${modelId}`, scopedOverrides);
 	}
 	if (!matchValue) {
 		matchValue = findLongestPrefixMatch(modelId, overrides);
@@ -226,9 +238,9 @@ export function applyCapabilityOverrides(
 	if (!matchValue) return capabilities;
 	const caps = matchValue.split(",").map((s) => s.trim());
 	const unknown = caps.filter((c) => c !== "" && !VALID_CAPS.includes(c));
-	if (unknown.length > 0) {
-		console.warn(
-			`[LiteLLM] Unknown capability overrides for "${modelId}": ${unknown.join(", ")}. Valid values: ${VALID_CAPS.join(", ")}`
+	if (unknown.length > 0 && log) {
+		log(
+			`WARNING: Unknown capability overrides for "${modelId}": ${unknown.join(", ")}. Valid values: ${VALID_CAPS.join(", ")}`
 		);
 	}
 	return {

--- a/src/test/provider/registration.test.ts
+++ b/src/test/provider/registration.test.ts
@@ -3,50 +3,84 @@ import { applyCapabilityOverrides } from "../../provider/registration";
 
 suite("applyCapabilityOverrides", () => {
 	test("enables toolCalling when override specifies it", () => {
-		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, { "my-model": "toolCalling" });
+		const result = applyCapabilityOverrides(
+			"my-model",
+			{ toolCalling: false, imageInput: false },
+			{ "my-model": "toolCalling" }
+		);
 		assert.strictEqual(result.toolCalling, true);
 		assert.strictEqual(result.imageInput, false);
 	});
 
 	test("enables imageInput when override specifies it", () => {
-		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, { "my-model": "imageInput" });
+		const result = applyCapabilityOverrides(
+			"my-model",
+			{ toolCalling: false, imageInput: false },
+			{ "my-model": "imageInput" }
+		);
 		assert.strictEqual(result.toolCalling, false);
 		assert.strictEqual(result.imageInput, true);
 	});
 
 	test("enables both capabilities", () => {
-		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, { "my-model": "toolCalling,imageInput" });
+		const result = applyCapabilityOverrides(
+			"my-model",
+			{ toolCalling: false, imageInput: false },
+			{ "my-model": "toolCalling,imageInput" }
+		);
 		assert.strictEqual(result.toolCalling, true);
 		assert.strictEqual(result.imageInput, true);
 	});
 
 	test("prefix matching applies override to longer model ID", () => {
-		const result = applyCapabilityOverrides("gpt-4-turbo", { toolCalling: false, imageInput: false }, { "gpt-4": "toolCalling" });
+		const result = applyCapabilityOverrides(
+			"gpt-4-turbo",
+			{ toolCalling: false, imageInput: false },
+			{ "gpt-4": "toolCalling" }
+		);
 		assert.strictEqual(result.toolCalling, true);
 	});
 
 	test("returns original capabilities when no override matches", () => {
-		const result = applyCapabilityOverrides("claude-3", { toolCalling: false, imageInput: true }, { "gpt-4": "toolCalling" });
+		const result = applyCapabilityOverrides(
+			"claude-3",
+			{ toolCalling: false, imageInput: true },
+			{ "gpt-4": "toolCalling" }
+		);
 		assert.strictEqual(result.toolCalling, false);
 		assert.strictEqual(result.imageInput, true);
 	});
 
 	test("does not disable capabilities that are already true", () => {
-		const result = applyCapabilityOverrides("my-model", { toolCalling: true, imageInput: true }, { "my-model": "toolCalling" });
+		const result = applyCapabilityOverrides(
+			"my-model",
+			{ toolCalling: true, imageInput: true },
+			{ "my-model": "toolCalling" }
+		);
 		assert.strictEqual(result.toolCalling, true);
 		assert.strictEqual(result.imageInput, true);
 	});
 
 	test("server-scoped override takes priority over unscoped", () => {
 		const overrides = { "my-model": "toolCalling", "Production/my-model": "imageInput" };
-		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, overrides, "Production");
+		const result = applyCapabilityOverrides(
+			"my-model",
+			{ toolCalling: false, imageInput: false },
+			overrides,
+			"Production"
+		);
 		assert.strictEqual(result.toolCalling, false);
 		assert.strictEqual(result.imageInput, true);
 	});
 
 	test("falls back to unscoped override when no server match", () => {
 		const overrides = { "my-model": "toolCalling", "Production/my-model": "imageInput" };
-		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, overrides, "Staging");
+		const result = applyCapabilityOverrides(
+			"my-model",
+			{ toolCalling: false, imageInput: false },
+			overrides,
+			"Staging"
+		);
 		assert.strictEqual(result.toolCalling, true);
 		assert.strictEqual(result.imageInput, false);
 	});

--- a/src/test/provider/registration.test.ts
+++ b/src/test/provider/registration.test.ts
@@ -36,4 +36,18 @@ suite("applyCapabilityOverrides", () => {
 		assert.strictEqual(result.toolCalling, true);
 		assert.strictEqual(result.imageInput, true);
 	});
+
+	test("server-scoped override takes priority over unscoped", () => {
+		const overrides = { "my-model": "toolCalling", "Production/my-model": "imageInput" };
+		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, overrides, "Production");
+		assert.strictEqual(result.toolCalling, false);
+		assert.strictEqual(result.imageInput, true);
+	});
+
+	test("falls back to unscoped override when no server match", () => {
+		const overrides = { "my-model": "toolCalling", "Production/my-model": "imageInput" };
+		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, overrides, "Staging");
+		assert.strictEqual(result.toolCalling, true);
+		assert.strictEqual(result.imageInput, false);
+	});
 });

--- a/src/test/provider/registration.test.ts
+++ b/src/test/provider/registration.test.ts
@@ -1,0 +1,39 @@
+import * as assert from "assert";
+import { applyCapabilityOverrides } from "../../provider/registration";
+
+suite("applyCapabilityOverrides", () => {
+	test("enables toolCalling when override specifies it", () => {
+		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, { "my-model": "toolCalling" });
+		assert.strictEqual(result.toolCalling, true);
+		assert.strictEqual(result.imageInput, false);
+	});
+
+	test("enables imageInput when override specifies it", () => {
+		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, { "my-model": "imageInput" });
+		assert.strictEqual(result.toolCalling, false);
+		assert.strictEqual(result.imageInput, true);
+	});
+
+	test("enables both capabilities", () => {
+		const result = applyCapabilityOverrides("my-model", { toolCalling: false, imageInput: false }, { "my-model": "toolCalling,imageInput" });
+		assert.strictEqual(result.toolCalling, true);
+		assert.strictEqual(result.imageInput, true);
+	});
+
+	test("prefix matching applies override to longer model ID", () => {
+		const result = applyCapabilityOverrides("gpt-4-turbo", { toolCalling: false, imageInput: false }, { "gpt-4": "toolCalling" });
+		assert.strictEqual(result.toolCalling, true);
+	});
+
+	test("returns original capabilities when no override matches", () => {
+		const result = applyCapabilityOverrides("claude-3", { toolCalling: false, imageInput: true }, { "gpt-4": "toolCalling" });
+		assert.strictEqual(result.toolCalling, false);
+		assert.strictEqual(result.imageInput, true);
+	});
+
+	test("does not disable capabilities that are already true", () => {
+		const result = applyCapabilityOverrides("my-model", { toolCalling: true, imageInput: true }, { "my-model": "toolCalling" });
+		assert.strictEqual(result.toolCalling, true);
+		assert.strictEqual(result.imageInput, true);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `modelCapabilitiesOverrides` setting to let users force-enable `toolCalling` and/or `imageInput` on models with incorrect metadata
- Uses longest-prefix matching on model IDs (e.g., override for `gpt-4` applies to `gpt-4-turbo`)
- Applies overrides at all 5 capability assignment sites in `buildModelInfos()`

## Test plan
- [x] `bun run compile` passes
- [x] All 146 tests pass including 6 new `applyCapabilityOverrides` tests
- [ ] F5 → add `"modelCapabilitiesOverrides": {"my-model": "toolCalling"}` → verify model shows tool calling support