### PR TITLE
feat: accurate token counting heuristic

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,6 +8,7 @@ import {
 	Progress,
 	ProvideLanguageModelChatResponseOptions,
 } from "vscode";
+import { countTextTokens, countMessageTokens } from "./tokenizer";
 
 import type { IssueReporter } from "./issueReporter";
 import type { ServerWithKey, ServerStatus } from "./extension/serverRegistry";
@@ -263,24 +264,9 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 		_token: CancellationToken
 	): Promise<number> {
 		if (typeof text === "string") {
-			return Math.ceil(text.length / 4);
+			return countTextTokens(text);
 		} else {
-			let totalTokens = 0;
-			for (const part of text.content) {
-				if (part instanceof vscode.LanguageModelTextPart) {
-					totalTokens += Math.ceil(part.value.length / 4);
-				} else if (part instanceof vscode.LanguageModelDataPart) {
-					const mime = part.mimeType.toLowerCase();
-					if (mime.startsWith("image/")) {
-						totalTokens += 765;
-					} else if (mime === "application/pdf") {
-						totalTokens += 500;
-					} else if (mime.startsWith("text/") || mime === "application/json" || mime.endsWith("+json")) {
-						totalTokens += Math.ceil(part.data.length / 4);
-					}
-				}
-			}
-			return totalTokens;
+			return countMessageTokens(text.content);
 		}
 	}
 }

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import type { LiteLLMProvider } from "../types";
 import { findLongestPrefixMatch, getModelDefaults } from "./modelDefaults";
-import { countTextTokens } from "../tokenizer";
+import { countTextTokens, countDataPartTokens } from "../tokenizer";
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 16000;
 const DEFAULT_CONTEXT_LENGTH = 128000;
@@ -70,11 +70,7 @@ export function estimateMessagesTokens(msgs: readonly vscode.LanguageModelChatRe
 			} else if (part instanceof vscode.LanguageModelToolCallPart) {
 				total += countTextTokens(part.name + JSON.stringify(part.input ?? {}));
 			} else if (part instanceof vscode.LanguageModelDataPart) {
-				const mime = part.mimeType.toLowerCase();
-				if (mime.startsWith("text/") || mime === "application/json" || mime.endsWith("+json")) {
-					const text = part.data instanceof Uint8Array ? new TextDecoder().decode(part.data) : String(part.data);
-					total += countTextTokens(text);
-				}
+				total += countDataPartTokens(part.mimeType, part.data);
 			}
 		}
 	}

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -72,7 +72,8 @@ export function estimateMessagesTokens(msgs: readonly vscode.LanguageModelChatRe
 			} else if (part instanceof vscode.LanguageModelDataPart) {
 				const mime = part.mimeType.toLowerCase();
 				if (mime.startsWith("text/") || mime === "application/json" || mime.endsWith("+json")) {
-					total += countTextTokens(String(part.data));
+					const text = part.data instanceof Uint8Array ? new TextDecoder().decode(part.data) : String(part.data);
+					total += countTextTokens(text);
 				}
 			}
 		}

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { LiteLLMProvider } from "../types";
 import { findLongestPrefixMatch, getModelDefaults } from "./modelDefaults";
+import { countTextTokens } from "../tokenizer";
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 16000;
 const DEFAULT_CONTEXT_LENGTH = 128000;
@@ -65,13 +66,13 @@ export function estimateMessagesTokens(msgs: readonly vscode.LanguageModelChatRe
 	for (const m of msgs) {
 		for (const part of m.content) {
 			if (part instanceof vscode.LanguageModelTextPart) {
-				total += Math.ceil(part.value.length / 4);
+				total += countTextTokens(part.value);
 			} else if (part instanceof vscode.LanguageModelToolCallPart) {
-				total += Math.ceil((part.name.length + JSON.stringify(part.input ?? {}).length) / 4);
+				total += countTextTokens(part.name + JSON.stringify(part.input ?? {}));
 			} else if (part instanceof vscode.LanguageModelDataPart) {
 				const mime = part.mimeType.toLowerCase();
 				if (mime.startsWith("text/") || mime === "application/json" || mime.endsWith("+json")) {
-					total += Math.ceil(part.data.length / 4);
+					total += countTextTokens(String(part.data));
 				}
 			}
 		}

--- a/src/test/tokenizer.test.ts
+++ b/src/test/tokenizer.test.ts
@@ -55,6 +55,17 @@ suite("Tokenizer", () => {
 		assert.equal(tokens, countTextTokens(json));
 	});
 
+	test("countMessageTokens handles tool result parts", () => {
+		const parts = [{ callId: "call_1", content: [{ value: "result text" }] }];
+		const tokens = countMessageTokens(parts);
+		assert.equal(tokens, countTextTokens("result text"));
+	});
+
+	test("countMessageTokens handles tool result with image content", () => {
+		const parts = [{ callId: "call_1", content: [{ mimeType: "image/png", data: new Uint8Array([1]) }] }];
+		assert.equal(countMessageTokens(parts), 765);
+	});
+
 	test("countMessageTokens sums mixed parts", () => {
 		const parts = [{ value: "describe this" }, { mimeType: "image/png", data: new Uint8Array([1]) }];
 		const tokens = countMessageTokens(parts);

--- a/src/test/tokenizer.test.ts
+++ b/src/test/tokenizer.test.ts
@@ -1,0 +1,58 @@
+import * as assert from "assert";
+import { countTextTokens, countMessageTokens } from "../tokenizer";
+
+suite("Tokenizer", () => {
+	test("countTextTokens returns 0 for empty string", () => {
+		assert.equal(countTextTokens(""), 0);
+	});
+
+	test("countTextTokens handles short text", () => {
+		const tokens = countTextTokens("hello world");
+		assert.ok(tokens > 0);
+		assert.equal(tokens, Math.ceil(Math.max("hello world".length / 3.5, 2 * 1.3)));
+	});
+
+	test("countTextTokens handles code with few spaces", () => {
+		const code = "const x=foo(bar,baz);";
+		const tokens = countTextTokens(code);
+		assert.equal(tokens, Math.ceil(code.length / 3.5));
+	});
+
+	test("countTextTokens handles many short words", () => {
+		const text = "I am a go to do it on";
+		const tokens = countTextTokens(text);
+		const words = text.split(/\s+/).filter(Boolean);
+		assert.equal(tokens, Math.ceil(Math.max(text.length / 3.5, words.length * 1.3)));
+	});
+
+	test("countMessageTokens handles text parts", () => {
+		const parts = [{ value: "hello world" }];
+		const tokens = countMessageTokens(parts);
+		assert.equal(tokens, countTextTokens("hello world"));
+	});
+
+	test("countMessageTokens handles tool call parts", () => {
+		const parts = [{ name: "myTool", input: { key: "val" } }];
+		const tokens = countMessageTokens(parts);
+		assert.equal(tokens, countTextTokens('myTool{"key":"val"}'));
+	});
+
+	test("countMessageTokens handles image data parts", () => {
+		const parts = [{ mimeType: "image/png", data: new Uint8Array([1, 2, 3]) }];
+		assert.equal(countMessageTokens(parts), 765);
+	});
+
+	test("countMessageTokens handles PDF data parts", () => {
+		const parts = [{ mimeType: "application/pdf", data: new Uint8Array([1]) }];
+		assert.equal(countMessageTokens(parts), 500);
+	});
+
+	test("countMessageTokens sums mixed parts", () => {
+		const parts = [
+			{ value: "describe this" },
+			{ mimeType: "image/png", data: new Uint8Array([1]) },
+		];
+		const tokens = countMessageTokens(parts);
+		assert.equal(tokens, countTextTokens("describe this") + 765);
+	});
+});

--- a/src/test/tokenizer.test.ts
+++ b/src/test/tokenizer.test.ts
@@ -47,11 +47,16 @@ suite("Tokenizer", () => {
 		assert.equal(countMessageTokens(parts), 500);
 	});
 
+	test("countMessageTokens decodes Uint8Array for text/json data parts", () => {
+		const json = '{"key":"value"}';
+		const data = new TextEncoder().encode(json);
+		const parts = [{ mimeType: "application/json", data }];
+		const tokens = countMessageTokens(parts);
+		assert.equal(tokens, countTextTokens(json));
+	});
+
 	test("countMessageTokens sums mixed parts", () => {
-		const parts = [
-			{ value: "describe this" },
-			{ mimeType: "image/png", data: new Uint8Array([1]) },
-		];
+		const parts = [{ value: "describe this" }, { mimeType: "image/png", data: new Uint8Array([1]) }];
 		const tokens = countMessageTokens(parts);
 		assert.equal(tokens, countTextTokens("describe this") + 765);
 	});

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,26 +1,53 @@
 export function countTextTokens(text: string): number {
-	if (!text) return 0;
+	if (!text) {
+		return 0;
+	}
 	const charEstimate = text.length / 3.5;
 	const words = text.split(/\s+/).filter(Boolean);
 	const wordEstimate = words.length * 1.3;
 	return Math.ceil(Math.max(charEstimate, wordEstimate));
 }
 
+interface TextPart {
+	value: string;
+}
+interface ToolCallPart {
+	name: string;
+	input: unknown;
+}
+interface DataPart {
+	mimeType: string;
+	data: Uint8Array | string;
+}
+
+function isTextPart(part: unknown): part is TextPart {
+	return !!part && typeof part === "object" && "value" in part && typeof (part as TextPart).value === "string";
+}
+
+function isToolCallPart(part: unknown): part is ToolCallPart {
+	return !!part && typeof part === "object" && "name" in part && "input" in part;
+}
+
+function isDataPart(part: unknown): part is DataPart {
+	return !!part && typeof part === "object" && "mimeType" in part && "data" in part;
+}
+
 export function countMessageTokens(content: ReadonlyArray<unknown>): number {
 	let total = 0;
 	for (const part of content) {
-		if (part && typeof part === "object" && "value" in part && typeof (part as any).value === "string") {
-			total += countTextTokens((part as any).value);
-		} else if (part && typeof part === "object" && "name" in part && "input" in part) {
-			total += countTextTokens((part as any).name + JSON.stringify((part as any).input ?? {}));
-		} else if (part && typeof part === "object" && "mimeType" in part && "data" in part) {
-			const mime = ((part as any).mimeType as string).toLowerCase();
+		if (isTextPart(part)) {
+			total += countTextTokens(part.value);
+		} else if (isToolCallPart(part)) {
+			total += countTextTokens(part.name + JSON.stringify(part.input ?? {}));
+		} else if (isDataPart(part)) {
+			const mime = part.mimeType.toLowerCase();
 			if (mime.startsWith("image/")) {
 				total += 765;
 			} else if (mime === "application/pdf") {
 				total += 500;
 			} else if (mime.startsWith("text/") || mime === "application/json" || mime.endsWith("+json")) {
-				total += countTextTokens(String((part as any).data));
+				const decoded = part.data instanceof Uint8Array ? new TextDecoder().decode(part.data) : String(part.data);
+				total += countTextTokens(decoded);
 			}
 		}
 	}

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -1,0 +1,28 @@
+export function countTextTokens(text: string): number {
+	if (!text) return 0;
+	const charEstimate = text.length / 3.5;
+	const words = text.split(/\s+/).filter(Boolean);
+	const wordEstimate = words.length * 1.3;
+	return Math.ceil(Math.max(charEstimate, wordEstimate));
+}
+
+export function countMessageTokens(content: ReadonlyArray<unknown>): number {
+	let total = 0;
+	for (const part of content) {
+		if (part && typeof part === "object" && "value" in part && typeof (part as any).value === "string") {
+			total += countTextTokens((part as any).value);
+		} else if (part && typeof part === "object" && "name" in part && "input" in part) {
+			total += countTextTokens((part as any).name + JSON.stringify((part as any).input ?? {}));
+		} else if (part && typeof part === "object" && "mimeType" in part && "data" in part) {
+			const mime = ((part as any).mimeType as string).toLowerCase();
+			if (mime.startsWith("image/")) {
+				total += 765;
+			} else if (mime === "application/pdf") {
+				total += 500;
+			} else if (mime.startsWith("text/") || mime === "application/json" || mime.endsWith("+json")) {
+				total += countTextTokens(String((part as any).data));
+			}
+		}
+	}
+	return total;
+}

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -19,6 +19,10 @@ interface DataPart {
 	mimeType: string;
 	data: Uint8Array | string;
 }
+interface ToolResultPart {
+	callId: string;
+	content?: ReadonlyArray<unknown>;
+}
 
 function isTextPart(part: unknown): part is TextPart {
 	return !!part && typeof part === "object" && "value" in part && typeof (part as TextPart).value === "string";
@@ -32,6 +36,52 @@ function isDataPart(part: unknown): part is DataPart {
 	return !!part && typeof part === "object" && "mimeType" in part && "data" in part;
 }
 
+function isToolResultPart(part: unknown): part is ToolResultPart {
+	return !!part && typeof part === "object" && "callId" in part && "content" in part;
+}
+
+function isPromptTsxPart(part: unknown): boolean {
+	if (!part || typeof part !== "object") {
+		return false;
+	}
+	const ctorName = (Object.getPrototypeOf(part as object) as { constructor?: { name?: string } } | undefined)
+		?.constructor?.name;
+	return ctorName === "LanguageModelPromptTsxPart";
+}
+
+function extractPromptTsxText(part: unknown): string {
+	const obj = part as Record<string, unknown>;
+	if (typeof obj.value === "string") {
+		return obj.value;
+	}
+	if (obj.value !== undefined && obj.value !== null) {
+		try {
+			return JSON.stringify(obj.value);
+		} catch {
+			return "";
+		}
+	}
+	return "";
+}
+
+export const IMAGE_TOKEN_ESTIMATE = 765;
+export const PDF_TOKEN_ESTIMATE = 500;
+
+export function countDataPartTokens(mime: string, data: Uint8Array | string): number {
+	const lower = mime.toLowerCase();
+	if (lower.startsWith("image/")) {
+		return IMAGE_TOKEN_ESTIMATE;
+	}
+	if (lower === "application/pdf") {
+		return PDF_TOKEN_ESTIMATE;
+	}
+	if (lower.startsWith("text/") || lower === "application/json" || lower.endsWith("+json")) {
+		const decoded = data instanceof Uint8Array ? new TextDecoder().decode(data) : String(data);
+		return countTextTokens(decoded);
+	}
+	return 0;
+}
+
 export function countMessageTokens(content: ReadonlyArray<unknown>): number {
 	let total = 0;
 	for (const part of content) {
@@ -40,15 +90,17 @@ export function countMessageTokens(content: ReadonlyArray<unknown>): number {
 		} else if (isToolCallPart(part)) {
 			total += countTextTokens(part.name + JSON.stringify(part.input ?? {}));
 		} else if (isDataPart(part)) {
-			const mime = part.mimeType.toLowerCase();
-			if (mime.startsWith("image/")) {
-				total += 765;
-			} else if (mime === "application/pdf") {
-				total += 500;
-			} else if (mime.startsWith("text/") || mime === "application/json" || mime.endsWith("+json")) {
-				const decoded = part.data instanceof Uint8Array ? new TextDecoder().decode(part.data) : String(part.data);
-				total += countTextTokens(decoded);
+			total += countDataPartTokens(part.mimeType, part.data);
+		} else if (isToolResultPart(part)) {
+			for (const sub of part.content ?? []) {
+				if (isTextPart(sub)) {
+					total += countTextTokens(sub.value);
+				} else if (isDataPart(sub)) {
+					total += countDataPartTokens(sub.mimeType, sub.data);
+				}
 			}
+		} else if (isPromptTsxPart(part)) {
+			total += countTextTokens(extractPromptTsxText(part));
 		}
 	}
 	return total;


### PR DESCRIPTION
## Summary
- Extract token counting into `src/tokenizer.ts` with dual char/word estimation (max of len/3.5 and words*1.3)
- Replace all `Math.ceil(length / 4)` usage in `provider.ts` and `provider/request.ts`
- Add 9 unit tests for the new tokenizer module

## Test plan
- [x] `bun run compile` passes
- [x] All 149 tests pass (`bun run test`)
- [x] Token counts are slightly higher (more conservative/safer for context window management)