### PR TITLE
feat: auto-strip unsupported params for incompatible models

### DIFF
--- a/scripts/capture-server.js
+++ b/scripts/capture-server.js
@@ -9,7 +9,7 @@
 const http = require("http");
 const { URL } = require("url");
 
-const MODEL_ID = "openai/gpt-5-mini-flex";
+const MODEL_ID = "openai/gpt-4o-test";
 
 const MODEL_INFO = {
 	data: [

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -3,12 +3,7 @@ import type { LiteLLMProvider } from "../types";
 import { findLongestPrefixMatch, getModelDefaults } from "./modelDefaults";
 
 const KNOWN_PARAMETER_LIMITATIONS: Record<string, Set<string>> = {
-	"claude-3-5-sonnet": new Set(["temperature"]),
-	"claude-3-5-haiku": new Set(["temperature"]),
-	"claude-3-opus": new Set(["temperature"]),
-	"claude-3-sonnet": new Set(["temperature"]),
-	"claude-3-haiku": new Set(["temperature"]),
-	"claude-haiku-4-5": new Set(["temperature"]),
+	claude: new Set(["temperature"]),
 	o1: new Set(["temperature", "top_p", "frequency_penalty", "presence_penalty"]),
 	"gpt-5": new Set(["temperature", "top_p", "frequency_penalty", "presence_penalty"]),
 	"gpt-5.1-codex": new Set(["temperature", "frequency_penalty", "presence_penalty"]),

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -9,7 +9,7 @@ const KNOWN_PARAMETER_LIMITATIONS: Record<string, Set<string>> = {
 	"claude-3-sonnet": new Set(["temperature"]),
 	"claude-3-haiku": new Set(["temperature"]),
 	"claude-haiku-4-5": new Set(["temperature"]),
-	"o1-": new Set(["temperature", "top_p", "frequency_penalty", "presence_penalty"]),
+	o1: new Set(["temperature", "top_p", "frequency_penalty", "presence_penalty"]),
 	"gpt-5": new Set(["temperature", "top_p", "frequency_penalty", "presence_penalty"]),
 	"gpt-5.1-codex": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
 	"codex-mini": new Set(["temperature", "frequency_penalty", "presence_penalty"]),

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -2,6 +2,29 @@ import * as vscode from "vscode";
 import type { LiteLLMProvider } from "../types";
 import { findLongestPrefixMatch, getModelDefaults } from "./modelDefaults";
 
+const KNOWN_PARAMETER_LIMITATIONS: Record<string, Set<string>> = {
+	"claude-3-5-sonnet": new Set(["temperature"]),
+	"claude-3-5-haiku": new Set(["temperature"]),
+	"claude-3-opus": new Set(["temperature"]),
+	"claude-3-sonnet": new Set(["temperature"]),
+	"claude-3-haiku": new Set(["temperature"]),
+	"claude-haiku-4-5": new Set(["temperature"]),
+	"o1-": new Set(["temperature", "top_p", "frequency_penalty", "presence_penalty"]),
+	"gpt-5": new Set(["temperature", "top_p", "frequency_penalty", "presence_penalty"]),
+	"gpt-5.1-codex": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
+	"codex-mini": new Set(["temperature", "frequency_penalty", "presence_penalty"]),
+};
+
+export function stripUnsupportedParams(body: Record<string, unknown>, rawModelId: string): void {
+	const modelName = rawModelId.includes("/") ? rawModelId.slice(rawModelId.lastIndexOf("/") + 1) : rawModelId;
+	const unsupported = findLongestPrefixMatch(modelName, KNOWN_PARAMETER_LIMITATIONS);
+	if (unsupported) {
+		for (const param of unsupported) {
+			delete body[param];
+		}
+	}
+}
+
 const DEFAULT_MAX_OUTPUT_TOKENS = 16000;
 const DEFAULT_CONTEXT_LENGTH = 128000;
 
@@ -149,5 +172,6 @@ export function buildRequestBody(params: RequestBodyParams): Record<string, unkn
 		body.tool_choice = toolConfig.tool_choice;
 	}
 
+	stripUnsupportedParams(body, rawModelId);
 	return body;
 }

--- a/src/test/host-fidelity.test.ts
+++ b/src/test/host-fidelity.test.ts
@@ -904,8 +904,8 @@ suite("Host-Fidelity Tests (multi-server)", function () {
 			await config.update(
 				"modelParameters",
 				{
-					"openai/gpt-5-mini-flex": { temperature: 0.5 },
-					"ServerA/openai/gpt-5-mini-flex": { temperature: 0.2 },
+					"openai/gpt-4o-test": { temperature: 0.5 },
+					"ServerA/openai/gpt-4o-test": { temperature: 0.2 },
 				},
 				vscode.ConfigurationTarget.Global
 			);
@@ -939,8 +939,8 @@ suite("Host-Fidelity Tests (multi-server)", function () {
 			await config.update(
 				"modelParameters",
 				{
-					"openai/gpt-5-mini-flex": { temperature: 0.5 },
-					"ServerA/openai/gpt-5-mini-flex": { temperature: 0.2 },
+					"openai/gpt-4o-test": { temperature: 0.5 },
+					"ServerA/openai/gpt-4o-test": { temperature: 0.2 },
 				},
 				vscode.ConfigurationTarget.Global
 			);

--- a/src/test/provider/request.test.ts
+++ b/src/test/provider/request.test.ts
@@ -1,0 +1,46 @@
+import * as assert from "assert";
+import { buildRequestBody } from "../../provider/request";
+
+function buildWithParams(rawModelId: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+	return buildRequestBody({
+		rawModelId,
+		openaiMessages: [],
+		maxTokens: 1000,
+		modelParams: { _replaceDefaults: true, temperature: 0.5, top_p: 0.9, frequency_penalty: 0.1, presence_penalty: 0.2, ...extra },
+		toolConfig: {},
+	});
+}
+
+suite("buildRequestBody param filtering", () => {
+	test("o1 model strips temperature, top_p, frequency_penalty, presence_penalty", () => {
+		const body = buildWithParams("o1-preview");
+		assert.strictEqual(body.temperature, undefined);
+		assert.strictEqual(body.top_p, undefined);
+		assert.strictEqual(body.frequency_penalty, undefined);
+		assert.strictEqual(body.presence_penalty, undefined);
+	});
+
+	test("claude model strips temperature", () => {
+		const body = buildWithParams("claude-3-5-sonnet-20241022");
+		assert.strictEqual(body.temperature, undefined);
+		assert.strictEqual(body.top_p, 0.9);
+		assert.strictEqual(body.frequency_penalty, 0.1);
+		assert.strictEqual(body.presence_penalty, 0.2);
+	});
+
+	test("gpt-4o retains all params", () => {
+		const body = buildWithParams("gpt-4o");
+		assert.strictEqual(body.temperature, 0.5);
+		assert.strictEqual(body.top_p, 0.9);
+		assert.strictEqual(body.frequency_penalty, 0.1);
+		assert.strictEqual(body.presence_penalty, 0.2);
+	});
+
+	test("gpt-5.1-codex strips temperature, frequency_penalty, presence_penalty but keeps top_p", () => {
+		const body = buildWithParams("gpt-5.1-codex");
+		assert.strictEqual(body.temperature, undefined);
+		assert.strictEqual(body.top_p, 0.9);
+		assert.strictEqual(body.frequency_penalty, undefined);
+		assert.strictEqual(body.presence_penalty, undefined);
+	});
+});

--- a/src/test/provider/request.test.ts
+++ b/src/test/provider/request.test.ts
@@ -6,7 +6,14 @@ function buildWithParams(rawModelId: string, extra: Record<string, unknown> = {}
 		rawModelId,
 		openaiMessages: [],
 		maxTokens: 1000,
-		modelParams: { _replaceDefaults: true, temperature: 0.5, top_p: 0.9, frequency_penalty: 0.1, presence_penalty: 0.2, ...extra },
+		modelParams: {
+			_replaceDefaults: true,
+			temperature: 0.5,
+			top_p: 0.9,
+			frequency_penalty: 0.1,
+			presence_penalty: 0.2,
+			...extra,
+		},
 		toolConfig: {},
 	});
 }
@@ -42,5 +49,19 @@ suite("buildRequestBody param filtering", () => {
 		assert.strictEqual(body.top_p, 0.9);
 		assert.strictEqual(body.frequency_penalty, undefined);
 		assert.strictEqual(body.presence_penalty, undefined);
+	});
+
+	test("provider-prefixed model ID strips params correctly", () => {
+		const body = buildWithParams("openai/o1-preview");
+		assert.strictEqual(body.temperature, undefined);
+		assert.strictEqual(body.top_p, undefined);
+		assert.strictEqual(body.frequency_penalty, undefined);
+		assert.strictEqual(body.presence_penalty, undefined);
+	});
+
+	test("provider-prefixed unmatched model retains all params", () => {
+		const body = buildWithParams("openai/gpt-4o");
+		assert.strictEqual(body.temperature, 0.5);
+		assert.strictEqual(body.top_p, 0.9);
 	});
 });

--- a/src/test/provider/request.test.ts
+++ b/src/test/provider/request.test.ts
@@ -72,4 +72,26 @@ suite("buildRequestBody param filtering", () => {
 		assert.strictEqual(body.temperature, 0.5);
 		assert.strictEqual(body.top_p, 0.9);
 	});
+
+	test("built-in default temperature is stripped for incompatible models", () => {
+		const body = buildRequestBody({
+			rawModelId: "claude-sonnet-4-20250514",
+			openaiMessages: [],
+			maxTokens: 1000,
+			modelParams: {},
+			toolConfig: {},
+		});
+		assert.strictEqual(body.temperature, undefined, "default temperature 0.7 should be stripped for Claude");
+	});
+
+	test("built-in default temperature is stripped for o1", () => {
+		const body = buildRequestBody({
+			rawModelId: "o1",
+			openaiMessages: [],
+			maxTokens: 1000,
+			modelParams: {},
+			toolConfig: {},
+		});
+		assert.strictEqual(body.temperature, undefined, "default temperature 0.7 should be stripped for o1");
+	});
 });

--- a/src/test/provider/request.test.ts
+++ b/src/test/provider/request.test.ts
@@ -27,6 +27,14 @@ suite("buildRequestBody param filtering", () => {
 		assert.strictEqual(body.presence_penalty, undefined);
 	});
 
+	test("base o1 model also strips params", () => {
+		const body = buildWithParams("o1");
+		assert.strictEqual(body.temperature, undefined);
+		assert.strictEqual(body.top_p, undefined);
+		assert.strictEqual(body.frequency_penalty, undefined);
+		assert.strictEqual(body.presence_penalty, undefined);
+	});
+
 	test("claude model strips temperature", () => {
 		const body = buildWithParams("claude-3-5-sonnet-20241022");
 		assert.strictEqual(body.temperature, undefined);


### PR DESCRIPTION
## Summary
- Add parameter compatibility filtering that auto-strips unsupported request params (e.g., `temperature`, `top_p`) for model families that reject them (O1, Claude, GPT-5, Codex)
- Uses longest-prefix matching against model name (after stripping provider prefix) to select the most specific rule
- Update capture server test model ID to avoid false matches with the `gpt-5` filter

## Test plan
- [x] Unit tests for O1, Claude, GPT-4o (no-op), and GPT-5.1-codex param stripping
- [x] `bun run compile` passes
- [x] Existing host-fidelity tests unaffected (2 pre-existing failures remain)