### PR TITLE
feat: discovery deduplication and TTL cache

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,6 +121,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 			try {
 				await statusBar.updateStatusBar({ state: "loading" });
+				provider.invalidateModelCache();
 
 				const models = await provider.prepareLanguageModelChatInformation(
 					{ silent: false },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,6 +57,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const provider = new LiteLLMChatModelProvider(context.secrets, ua, outputChannel, issueReporter);
 
 	provider.setServerProvider(() => registry.getServersWithKeys());
+	registry.setOnChangeCallback(() => provider.invalidateModelCache());
 
 	registry.migrateLegacy().then((migrated) => {
 		if (migrated) {

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -40,6 +40,7 @@ export function registerTestCommands(
 			options: { silent: boolean },
 			token: vscode.CancellationToken
 		) => Promise<vscode.LanguageModelChatInformation[]>;
+		invalidateModelCache: () => void;
 	}
 ): void {
 	if (context.extensionMode !== vscode.ExtensionMode.Production) {
@@ -49,6 +50,7 @@ export function registerTestCommands(
 				await context.secrets.store("litellm.apiKey", apiKey || "");
 			}),
 			vscode.commands.registerCommand("litellm._test.refreshModels", async () => {
+				provider.invalidateModelCache();
 				const infos = await provider.prepareLanguageModelChatInformation(
 					{ silent: true },
 					new vscode.CancellationTokenSource().token

--- a/src/extension/serverRegistry.ts
+++ b/src/extension/serverRegistry.ts
@@ -27,10 +27,20 @@ function apiKeySecret(serverId: string): string {
 }
 
 export class ServerRegistry {
+	private _onChangeCallback?: () => void;
+
 	constructor(
 		private readonly globalState: vscode.Memento,
 		private readonly secrets: vscode.SecretStorage
 	) {}
+
+	setOnChangeCallback(callback: () => void): void {
+		this._onChangeCallback = callback;
+	}
+
+	private notifyChange(): void {
+		this._onChangeCallback?.();
+	}
 
 	getServers(): ServerConfig[] {
 		return this.globalState.get<ServerConfig[]>(REGISTRY_KEY, []);
@@ -49,6 +59,7 @@ export class ServerRegistry {
 		if (apiKey) {
 			await this.secrets.store(apiKeySecret(id), apiKey);
 		}
+		this.notifyChange();
 		return server;
 	}
 
@@ -67,12 +78,14 @@ export class ServerRegistry {
 				await this.secrets.delete(apiKeySecret(id));
 			}
 		}
+		this.notifyChange();
 	}
 
 	async removeServer(id: string): Promise<void> {
 		const servers = this.getServers().filter((s) => s.id !== id);
 		await this.globalState.update(REGISTRY_KEY, servers);
 		await this.secrets.delete(apiKeySecret(id));
+		this.notifyChange();
 	}
 
 	async getApiKey(serverId: string): Promise<string> {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -81,8 +81,8 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	): Promise<LanguageModelChatInformation[]> {
 		this.log("prepareLanguageModelChatInformation called", { silent: options.silent });
 
-		if (this._inFlightDiscovery) {
-			this.log("Returning in-flight discovery promise");
+		if (this._inFlightDiscovery && options.silent) {
+			this.log("Returning in-flight discovery promise (silent coalescing)");
 			return this._inFlightDiscovery;
 		}
 
@@ -93,156 +93,157 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 		}
 
 		this._inFlightDiscovery = (async () => {
-		try {
-		const servers = await ensureServers(options.silent, this._getServers, this.secrets);
-		if (!servers || servers.length === 0) {
-			this.log("No servers configured, returning empty array");
+			try {
+				const servers = await ensureServers(options.silent, this._getServers, this.secrets);
+				if (!servers || servers.length === 0) {
+					this.log("No servers configured, returning empty array");
 
-			if (options.silent && !this._hasShownNoConfigNotification) {
-				this._hasShownNoConfigNotification = true;
-				vscode.window
-					.showWarningMessage("LiteLLM: No servers configured. Click to configure.", "Configure Now", "Dismiss")
-					.then((choice) => {
-						if (choice === "Configure Now") {
-							vscode.commands.executeCommand("litellm.manage");
-						}
-					});
-			}
-
-			if (this._statusCallback) {
-				this._statusCallback({ serverStatuses: [], totalModels: 0 });
-			}
-			return [];
-		}
-
-		this.log("Fetching models from servers", { count: servers.length, labels: servers.map((s) => s.label) });
-
-		const results = await Promise.allSettled(
-			servers.map(async (server) => {
-				const result = await fetchModels(
-					server.apiKey,
-					server.baseUrl,
-					this.userAgent,
-					(msg, data) => this.log(msg, data),
-					(msg, err) => this.logError(msg, err)
-				);
-				return { server, models: result.models };
-			})
-		);
-
-		const serverStatuses: ServerStatus[] = [];
-		const allInfos: LanguageModelChatInformation[] = [];
-
-		const successfulCount = results.filter((r) => r.status === "fulfilled").length;
-		const serverCount = servers.length;
-
-		if (successfulCount > 0) {
-			this._modelRoutes.clear();
-			this._promptCachingSupport.clear();
-		}
-
-		for (let i = 0; i < results.length; i++) {
-			const result = results[i];
-			const server = servers[i];
-
-			if (result.status === "rejected") {
-				const errorMsg = result.reason instanceof Error ? result.reason.message : String(result.reason);
-				this.logError(`Failed to fetch models from server "${server.label}"`, result.reason);
-				serverStatuses.push({
-					serverId: server.id,
-					label: server.label,
-					baseUrl: server.baseUrl,
-					state: "error",
-					modelCount: 0,
-					error: errorMsg,
-					lastChecked: new Date().toISOString(),
-				});
-				continue;
-			}
-
-			const { models } = result.value;
-			this.log(`Server "${server.label}" returned ${models.length} models`);
-
-			const reg = buildModelInfos(models, server, serverCount, (msg) => this.log(msg));
-			allInfos.push(...reg.infos);
-			for (const [k, v] of reg.routes) {
-				this._modelRoutes.set(k, v);
-			}
-			for (const [k, v] of reg.promptCaching) {
-				this._promptCachingSupport.set(k, v);
-			}
-
-			serverStatuses.push({
-				serverId: server.id,
-				label: server.label,
-				baseUrl: server.baseUrl,
-				state: "ok",
-				modelCount: reg.infos.length,
-				lastChecked: new Date().toISOString(),
-			});
-		}
-
-		this._chatEndpoints = allInfos.map((info) => ({
-			model: info.id,
-			modelMaxPromptTokens: info.maxInputTokens + info.maxOutputTokens,
-		}));
-
-		this.log("Final model count:", allInfos.length);
-
-		if (this._statusCallback) {
-			this._statusCallback({ serverStatuses, totalModels: allInfos.length });
-		}
-
-		if (allInfos.length === 0 && successfulCount > 0) {
-			vscode.window
-				.showWarningMessage(
-					"LiteLLM: Your servers returned no models. Check your LiteLLM proxy configuration.",
-					"Check Server",
-					"Reconfigure",
-					"Report Issue"
-				)
-				.then((choice) => {
-					if (choice === "Check Server") {
-						vscode.commands.executeCommand("litellm.testConnection");
-					} else if (choice === "Reconfigure") {
-						vscode.commands.executeCommand("litellm.manage");
-					} else if (choice === "Report Issue") {
-						vscode.commands.executeCommand("litellm.reportIssue");
+					if (options.silent && !this._hasShownNoConfigNotification) {
+						this._hasShownNoConfigNotification = true;
+						vscode.window
+							.showWarningMessage("LiteLLM: No servers configured. Click to configure.", "Configure Now", "Dismiss")
+							.then((choice) => {
+								if (choice === "Configure Now") {
+									vscode.commands.executeCommand("litellm.manage");
+								}
+							});
 					}
-				});
-		}
 
-		if (successfulCount === 0 && servers.length > 0) {
-			const firstError = serverStatuses.find((s) => s.error)?.error ?? "Unknown error";
-			if (options.silent) {
-				vscode.window
-					.showErrorMessage(`LiteLLM: ${firstError}`, "Reconfigure", "Report Issue", "Dismiss")
-					.then((choice) => {
-						if (choice === "Reconfigure") {
-							vscode.commands.executeCommand("litellm.manage");
-						} else if (choice === "Report Issue") {
-							vscode.commands.executeCommand("litellm.reportIssue");
-						}
+					if (this._statusCallback) {
+						this._statusCallback({ serverStatuses: [], totalModels: 0 });
+					}
+					return [];
+				}
+
+				this.log("Fetching models from servers", { count: servers.length, labels: servers.map((s) => s.label) });
+
+				const results = await Promise.allSettled(
+					servers.map(async (server) => {
+						const result = await fetchModels(
+							server.apiKey,
+							server.baseUrl,
+							this.userAgent,
+							(msg, data) => this.log(msg, data),
+							(msg, err) => this.logError(msg, err)
+						);
+						return { server, models: result.models };
+					})
+				);
+
+				const serverStatuses: ServerStatus[] = [];
+				const allInfos: LanguageModelChatInformation[] = [];
+
+				const successfulCount = results.filter((r) => r.status === "fulfilled").length;
+				const serverCount = servers.length;
+
+				if (successfulCount > 0) {
+					this._modelRoutes.clear();
+					this._promptCachingSupport.clear();
+				}
+
+				for (let i = 0; i < results.length; i++) {
+					const result = results[i];
+					const server = servers[i];
+
+					if (result.status === "rejected") {
+						const errorMsg = result.reason instanceof Error ? result.reason.message : String(result.reason);
+						this.logError(`Failed to fetch models from server "${server.label}"`, result.reason);
+						serverStatuses.push({
+							serverId: server.id,
+							label: server.label,
+							baseUrl: server.baseUrl,
+							state: "error",
+							modelCount: 0,
+							error: errorMsg,
+							lastChecked: new Date().toISOString(),
+						});
+						continue;
+					}
+
+					const { models } = result.value;
+					this.log(`Server "${server.label}" returned ${models.length} models`);
+
+					const reg = buildModelInfos(models, server, serverCount, (msg) => this.log(msg));
+					allInfos.push(...reg.infos);
+					for (const [k, v] of reg.routes) {
+						this._modelRoutes.set(k, v);
+					}
+					for (const [k, v] of reg.promptCaching) {
+						this._promptCachingSupport.set(k, v);
+					}
+
+					serverStatuses.push({
+						serverId: server.id,
+						label: server.label,
+						baseUrl: server.baseUrl,
+						state: "ok",
+						modelCount: reg.infos.length,
+						lastChecked: new Date().toISOString(),
 					});
-				this._lastModelList = [];
-				this._modelListFetchedAtMs = Date.now();
-				return [];
-			}
-			throw new Error(firstError);
-		}
+				}
 
-		this._lastModelList = allInfos;
-		this._modelListFetchedAtMs = Date.now();
-		return allInfos;
-		} finally {
-			this._inFlightDiscovery = undefined;
-		}
+				this._chatEndpoints = allInfos.map((info) => ({
+					model: info.id,
+					modelMaxPromptTokens: info.maxInputTokens + info.maxOutputTokens,
+				}));
+
+				this.log("Final model count:", allInfos.length);
+
+				if (this._statusCallback) {
+					this._statusCallback({ serverStatuses, totalModels: allInfos.length });
+				}
+
+				if (allInfos.length === 0 && successfulCount > 0) {
+					vscode.window
+						.showWarningMessage(
+							"LiteLLM: Your servers returned no models. Check your LiteLLM proxy configuration.",
+							"Check Server",
+							"Reconfigure",
+							"Report Issue"
+						)
+						.then((choice) => {
+							if (choice === "Check Server") {
+								vscode.commands.executeCommand("litellm.testConnection");
+							} else if (choice === "Reconfigure") {
+								vscode.commands.executeCommand("litellm.manage");
+							} else if (choice === "Report Issue") {
+								vscode.commands.executeCommand("litellm.reportIssue");
+							}
+						});
+				}
+
+				if (successfulCount === 0 && servers.length > 0) {
+					const firstError = serverStatuses.find((s) => s.error)?.error ?? "Unknown error";
+					if (options.silent) {
+						vscode.window
+							.showErrorMessage(`LiteLLM: ${firstError}`, "Reconfigure", "Report Issue", "Dismiss")
+							.then((choice) => {
+								if (choice === "Reconfigure") {
+									vscode.commands.executeCommand("litellm.manage");
+								} else if (choice === "Report Issue") {
+									vscode.commands.executeCommand("litellm.reportIssue");
+								}
+							});
+						this._lastModelList = [];
+						this._modelListFetchedAtMs = Date.now();
+						return [];
+					}
+					throw new Error(firstError);
+				}
+
+				this._lastModelList = allInfos;
+				this._modelListFetchedAtMs = Date.now();
+				return allInfos;
+			} finally {
+				this._inFlightDiscovery = undefined;
+			}
 		})();
 		return this._inFlightDiscovery;
 	}
 
 	invalidateModelCache(): void {
 		this._modelListFetchedAtMs = 0;
+		this._inFlightDiscovery = undefined;
 	}
 
 	async provideLanguageModelChatInformation(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -32,6 +32,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	private _modelRoutes = new Map<string, ModelRoute>();
 	private _getServers?: () => Promise<ServerWithKey[]>;
 	private _inFlightDiscovery: Promise<LanguageModelChatInformation[]> | undefined;
+	private _discoveryGeneration = 0;
 	private _lastModelList: LanguageModelChatInformation[] = [];
 	private _modelListFetchedAtMs = 0;
 
@@ -92,7 +93,8 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 			return this._lastModelList;
 		}
 
-		this._inFlightDiscovery = (async () => {
+		const myGeneration = this._discoveryGeneration;
+		const promise = (async () => {
 			try {
 				const servers = await ensureServers(options.silent, this._getServers, this.secrets);
 				if (!servers || servers.length === 0) {
@@ -235,14 +237,20 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 				this._modelListFetchedAtMs = Date.now();
 				return allInfos;
 			} finally {
-				this._inFlightDiscovery = undefined;
+				if (this._discoveryGeneration === myGeneration) {
+					this._inFlightDiscovery = undefined;
+				}
 			}
 		})();
-		return this._inFlightDiscovery;
+		if (options.silent) {
+			this._inFlightDiscovery = promise;
+		}
+		return promise;
 	}
 
 	invalidateModelCache(): void {
 		this._modelListFetchedAtMs = 0;
+		this._discoveryGeneration++;
 		this._inFlightDiscovery = undefined;
 	}
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -226,8 +226,8 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 									vscode.commands.executeCommand("litellm.reportIssue");
 								}
 							});
-						this._lastModelList = [];
 						if (this._discoveryGeneration === myGeneration) {
+							this._lastModelList = [];
 							this._modelListFetchedAtMs = Date.now();
 						}
 						return [];

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -88,7 +88,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 		}
 
 		const TTL_MS = 30_000;
-		if (options.silent && this._lastModelList.length > 0 && Date.now() - this._modelListFetchedAtMs < TTL_MS) {
+		if (options.silent && this._modelListFetchedAtMs > 0 && Date.now() - this._modelListFetchedAtMs < TTL_MS) {
 			this.log("Returning cached models (within TTL)", { count: this._lastModelList.length });
 			return this._lastModelList;
 		}
@@ -227,14 +227,18 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 								}
 							});
 						this._lastModelList = [];
-						this._modelListFetchedAtMs = Date.now();
+						if (this._discoveryGeneration === myGeneration) {
+							this._modelListFetchedAtMs = Date.now();
+						}
 						return [];
 					}
 					throw new Error(firstError);
 				}
 
-				this._lastModelList = allInfos;
-				this._modelListFetchedAtMs = Date.now();
+				if (this._discoveryGeneration === myGeneration) {
+					this._lastModelList = allInfos;
+					this._modelListFetchedAtMs = Date.now();
+				}
 				return allInfos;
 			} finally {
 				if (this._discoveryGeneration === myGeneration) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -31,6 +31,9 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	private _toolCallIdCounter = 0;
 	private _modelRoutes = new Map<string, ModelRoute>();
 	private _getServers?: () => Promise<ServerWithKey[]>;
+	private _inFlightDiscovery: Promise<LanguageModelChatInformation[]> | undefined;
+	private _lastModelList: LanguageModelChatInformation[] = [];
+	private _modelListFetchedAtMs = 0;
 
 	constructor(
 		private readonly secrets: vscode.SecretStorage,
@@ -78,6 +81,19 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	): Promise<LanguageModelChatInformation[]> {
 		this.log("prepareLanguageModelChatInformation called", { silent: options.silent });
 
+		if (this._inFlightDiscovery) {
+			this.log("Returning in-flight discovery promise");
+			return this._inFlightDiscovery;
+		}
+
+		const TTL_MS = 30_000;
+		if (options.silent && this._lastModelList.length > 0 && Date.now() - this._modelListFetchedAtMs < TTL_MS) {
+			this.log("Returning cached models (within TTL)", { count: this._lastModelList.length });
+			return this._lastModelList;
+		}
+
+		this._inFlightDiscovery = (async () => {
+		try {
 		const servers = await ensureServers(options.silent, this._getServers, this.secrets);
 		if (!servers || servers.length === 0) {
 			this.log("No servers configured, returning empty array");
@@ -208,12 +224,25 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 							vscode.commands.executeCommand("litellm.reportIssue");
 						}
 					});
+				this._lastModelList = [];
+				this._modelListFetchedAtMs = Date.now();
 				return [];
 			}
 			throw new Error(firstError);
 		}
 
+		this._lastModelList = allInfos;
+		this._modelListFetchedAtMs = Date.now();
 		return allInfos;
+		} finally {
+			this._inFlightDiscovery = undefined;
+		}
+		})();
+		return this._inFlightDiscovery;
+	}
+
+	invalidateModelCache(): void {
+		this._modelListFetchedAtMs = 0;
 	}
 
 	async provideLanguageModelChatInformation(

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -1262,4 +1262,151 @@ suite("provider", () => {
 			assert.equal(modelEntry.capabilities.imageInput, true);
 		});
 	});
+
+	suite("discovery cache and deduplication", () => {
+		function makeModelResponse(modelIds: string[]) {
+			return async () =>
+				({
+					ok: true,
+					json: async () => ({
+						object: "list",
+						data: modelIds.map((id) => ({
+							id,
+							object: "model",
+							created: 0,
+							owned_by: "test",
+							providers: [{ provider: "test-provider", status: "active", supports_tools: true }],
+						})),
+					}),
+				}) as unknown as Response;
+		}
+
+		function makeProvider() {
+			return new LiteLLMChatModelProvider(
+				{
+					get: async (key: string) => (key === "litellm.baseUrl" ? "http://test" : "test-key"),
+					store: async () => {},
+					delete: async () => {},
+					onDidChange: (_listener: unknown) => ({ dispose() {} }),
+				} as unknown as vscode.SecretStorage,
+				"GitHubCopilotChat/test VSCode/test"
+			);
+		}
+
+		const token = new vscode.CancellationTokenSource().token;
+
+		test("TTL cache returns cached results for silent calls", async () => {
+			const originalFetch = global.fetch;
+			let fetchCount = 0;
+			global.fetch = async () => {
+				fetchCount++;
+				return (await makeModelResponse(["model-a"])()) as Response;
+			};
+
+			const provider = makeProvider();
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 1);
+
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 1, "Second silent call should use TTL cache");
+
+			global.fetch = originalFetch;
+		});
+
+		test("TTL cache is bypassed after invalidateModelCache", async () => {
+			const originalFetch = global.fetch;
+			let fetchCount = 0;
+			global.fetch = async () => {
+				fetchCount++;
+				return (await makeModelResponse(["model-a"])()) as Response;
+			};
+
+			const provider = makeProvider();
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 1);
+
+			provider.invalidateModelCache();
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 2, "Should re-fetch after invalidation");
+
+			global.fetch = originalFetch;
+		});
+
+		test("non-silent call bypasses TTL cache", async () => {
+			const originalFetch = global.fetch;
+			let fetchCount = 0;
+			global.fetch = async () => {
+				fetchCount++;
+				return (await makeModelResponse(["model-a"])()) as Response;
+			};
+
+			const provider = makeProvider();
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 1);
+
+			await provider.prepareLanguageModelChatInformation({ silent: false }, token);
+			assert.equal(fetchCount, 2, "Non-silent call should bypass cache");
+
+			global.fetch = originalFetch;
+		});
+
+		test("stale fetch does not overwrite cache after invalidation", async () => {
+			const originalFetch = global.fetch;
+			let fetchCount = 0;
+
+			const provider = makeProvider();
+
+			// First: populate cache with "old-model"
+			global.fetch = makeModelResponse(["old-model"]);
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			fetchCount = 0;
+
+			// Invalidate, then fetch with "new-model"
+			provider.invalidateModelCache();
+			global.fetch = async () => {
+				fetchCount++;
+				return (await makeModelResponse(["new-model"])()) as Response;
+			};
+			const result = await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 1);
+
+			const ids = result.map((m) => m.id);
+			assert.ok(
+				ids.some((id) => id.includes("new-model")),
+				`Should have new-model, got: ${ids.join(", ")}`
+			);
+			assert.ok(!ids.some((id) => id.includes("old-model")), `Should not have old-model, got: ${ids.join(", ")}`);
+
+			// Verify the cache holds new-model, not old
+			global.fetch = async () => {
+				throw new Error("should not fetch");
+			};
+			const cached = await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			const cachedIds = cached.map((m) => m.id);
+			assert.ok(
+				cachedIds.some((id) => id.includes("new-model")),
+				`Cache should have new-model, got: ${cachedIds.join(", ")}`
+			);
+
+			global.fetch = originalFetch;
+		});
+
+		test("empty model list is cached within TTL", async () => {
+			const originalFetch = global.fetch;
+			let fetchCount = 0;
+			global.fetch = async () => {
+				fetchCount++;
+				return { ok: true, json: async () => ({ object: "list", data: [] }) } as unknown as Response;
+			};
+
+			const provider = makeProvider();
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 1);
+
+			await provider.prepareLanguageModelChatInformation({ silent: true }, token);
+			assert.equal(fetchCount, 1, "Empty result should be cached within TTL");
+
+			global.fetch = originalFetch;
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Deduplicate concurrent `prepareLanguageModelChatInformation` calls by sharing a single in-flight promise
- Cache model list for 30 seconds on silent (background) calls to avoid redundant server requests
- Add `invalidateModelCache()` method, called by test-connection and test-refresh commands

## Test plan
- [x] `bun run compile` passes
- [x] All 140 tests pass (`bun run test`)
- [ ] F5 launch → open chat twice quickly → output channel shows "Returning in-flight discovery promise"
- [ ] F5 launch → open chat, wait 30s, reopen → fresh fetch (no cache log)