### PR TITLE
V0.2.6: Enable release notes and fix chat model picker for VS Code 1.120+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,13 +93,8 @@ jobs:
           body: |
             ## LiteLLM Provider for GitHub Copilot Chat v${{ needs.package.outputs.version }}
 
-            ### Installation from VSIX
-            1. Download the `extension.vsix` file
-            2. Open VS Code
-            3. Go to Extensions (Ctrl+Shift+X / Cmd+Shift+X)
-            4. Click the "..." menu at the top
-            5. Select "Install from VSIX..."
-            6. Choose the downloaded `extension.vsix` file
+            ## What's Changed
+            See the auto-generated release notes below for the full list of changes in this release.
 
             ### Installation from VS Code Marketplace
             Search for "LiteLLM" in the VS Code Extensions marketplace or visit:
@@ -111,6 +106,7 @@ jobs:
             - LiteLLM API key (if required)
 
             [Full documentation](https://github.com/Vivswan/litellm-vscode-chat#readme)
+          generate_release_notes: true
           files: |
             extension.vsix
           draft: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "litellm-vscode-chat",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Vivswan/litellm-vscode-chat"

--- a/src/provider/registration.ts
+++ b/src/provider/registration.ts
@@ -15,6 +15,7 @@ function withUserSelectableMetadata(info: LanguageModelChatInformation): Languag
 
 	return {
 		...info,
+		isUserSelectable: true,
 		metadata: {
 			...existingMetadata,
 			isUserSelectable: true,

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -238,8 +238,13 @@ suite("provider", () => {
 				const providerEntry = infos.find((i) => i.id === "test-model:test-provider");
 				assert.ok(providerEntry);
 
+				// VS Code 1.120+ requires isUserSelectable at top level
+				const topLevel = providerEntry as unknown as { isUserSelectable?: boolean };
+				assert.equal(topLevel.isUserSelectable, true, "isUserSelectable should be at top level for VS Code 1.120+");
+
+				// Also keep it in metadata for backward compatibility
 				const metadata = (providerEntry as unknown as { metadata?: { isUserSelectable?: boolean } }).metadata;
-				assert.equal(metadata?.isUserSelectable, true);
+				assert.equal(metadata?.isUserSelectable, true, "isUserSelectable should also be in metadata");
 			} finally {
 				global.fetch = originalFetch;
 			}


### PR DESCRIPTION
This pull request introduces a new release (v0.2.6) of the LiteLLM VS Code Chat extension, focusing on improving compatibility with newer versions of VS Code and streamlining the release workflow. The most significant changes include ensuring the `isUserSelectable` property is present at both the top level and within metadata for provider registration, updating release notes handling, and incrementing the extension version.

**Provider registration and compatibility improvements:**

* Updated the `withUserSelectableMetadata` function to add `isUserSelectable: true` at the top level of the provider registration object, ensuring compatibility with VS Code 1.120+ while retaining the property in `metadata` for backward compatibility.
* Enhanced tests in `provider.test.ts` to assert that `isUserSelectable` exists both at the top level and within `metadata`, verifying compatibility across VS Code versions.

**Release workflow improvements:**

* Changed the release workflow in `.github/workflows/release.yml` to generate auto-release notes and removed manual VSIX installation instructions, making release notes clearer and more maintainable. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L96-R97) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R109)

**Version bump:**

* Incremented the extension version from `0.2.5` to `0.2.6` in `package.json` to mark the new release.