### PR TITLE
fix: prevent diagnostics report truncation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { LiteLLMChatModelProvider } from "./provider";
 import type { AggregatedStatus } from "./provider";
-import { IssueReporter } from "./issueReporter";
+import { IssueReporter, createIssueReporterEnv } from "./issueReporter";
 import { ServerRegistry } from "./extension/serverRegistry";
 import { StatusBarManager } from "./extension/status";
 import { registerHelpAndFeedbackCommand, registerTestCommands } from "./extension/commands";
@@ -60,7 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(outputChannel);
 	outputChannel.appendLine(`LiteLLM Extension activated (v${extVersion})`);
 
-	const issueReporter = new IssueReporter();
+	const issueReporter = new IssueReporter(createIssueReporterEnv(context.globalStorageUri));
 	const registry = new ServerRegistry(context.globalState, context.secrets);
 	const provider = new LiteLLMChatModelProvider(context.secrets, ua, outputChannel, issueReporter);
 

--- a/src/issueReporter.ts
+++ b/src/issueReporter.ts
@@ -2,8 +2,8 @@ import * as vscode from "vscode";
 
 const GITHUB_REPO_URL = "https://github.com/Vivswan/litellm-vscode-chat";
 const MAX_LOG_ENTRIES = 50;
-const MAX_BODY_LENGTH = 1500;
 const MAX_URL_LENGTH = 8000;
+const COMPACT_STACK_LINES = 8;
 
 export interface ErrorContext {
 	source: string;
@@ -24,9 +24,70 @@ export interface DiagnosticsSnapshot {
 	recentLogs: string[];
 }
 
+interface BodyOptions {
+	recentLogs?: string[];
+	omittedLogCount?: number;
+	stackMode?: "full" | "compact";
+	compactedDiagnosticsHint?: string;
+}
+
+interface IssuePayload {
+	url: string;
+	fullBody: string;
+	compacted: boolean;
+}
+
+export interface IssueReporterEnv {
+	writeClipboard(text: string): PromiseLike<void>;
+	openExternal(uri: vscode.Uri): PromiseLike<boolean>;
+	saveDiagnosticsFile?(contents: string): PromiseLike<vscode.Uri>;
+	showCompactedDiagnosticsMessage?(diagnosticsFile?: vscode.Uri): PromiseLike<void>;
+}
+
+const defaultIssueReporterEnv: IssueReporterEnv = {
+	writeClipboard: (text) => vscode.env.clipboard.writeText(text),
+	openExternal: (uri) => vscode.env.openExternal(uri),
+	showCompactedDiagnosticsMessage: async () => {
+		await vscode.window.showInformationMessage(
+			"LiteLLM: Full diagnostics were too large to prefill in GitHub and were copied to your clipboard. Please paste them into the issue."
+		);
+	},
+};
+
+export function createIssueReporterEnv(diagnosticsDirectory: vscode.Uri): IssueReporterEnv {
+	return {
+		...defaultIssueReporterEnv,
+		saveDiagnosticsFile: async (contents) => {
+			const directory = vscode.Uri.joinPath(diagnosticsDirectory, "issue-diagnostics");
+			await vscode.workspace.fs.createDirectory(directory);
+			const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+			const file = vscode.Uri.joinPath(directory, `litellm-diagnostics-${timestamp}.md`);
+			await vscode.workspace.fs.writeFile(file, Buffer.from(contents, "utf8"));
+
+			const document = await vscode.workspace.openTextDocument(file);
+			await vscode.window.showTextDocument(document, { preview: false });
+			return file;
+		},
+		showCompactedDiagnosticsMessage: async (diagnosticsFile) => {
+			const choice = await vscode.window.showInformationMessage(
+				diagnosticsFile
+					? "LiteLLM: Full diagnostics were saved to a redacted log file and copied to your clipboard. Attach the file to the GitHub issue or paste the contents."
+					: "LiteLLM: Full diagnostics were too large to prefill in GitHub and were copied to your clipboard. Please paste them into the issue.",
+				...(diagnosticsFile ? ["Reveal File"] : [])
+			);
+
+			if (choice === "Reveal File" && diagnosticsFile) {
+				await vscode.commands.executeCommand("revealFileInOS", diagnosticsFile);
+			}
+		},
+	};
+}
+
 export class IssueReporter {
 	private _logBuffer: string[] = [];
 	private _latestError?: ErrorContext;
+
+	constructor(private readonly env: IssueReporterEnv = defaultIssueReporterEnv) {}
 
 	appendLog(message: string): void {
 		this._logBuffer.push(message);
@@ -55,29 +116,7 @@ export class IssueReporter {
 	}
 
 	buildIssueUrl(snapshot: DiagnosticsSnapshot): string {
-		const title = this.buildTitle(snapshot);
-		const body = this.buildBody(snapshot);
-		let truncatedBody = body.length > MAX_BODY_LENGTH ? body.slice(0, MAX_BODY_LENGTH) + "\n\n...(truncated)" : body;
-
-		const params = new URLSearchParams({
-			labels: "bug",
-			title,
-			body: truncatedBody,
-		});
-
-		let url = `${GITHUB_REPO_URL}/issues/new?${params.toString()}`;
-
-		if (url.length > MAX_URL_LENGTH) {
-			truncatedBody = body.slice(0, 800) + "\n\n...(truncated, full diagnostics copied to clipboard)";
-			const shortParams = new URLSearchParams({
-				labels: "bug",
-				title,
-				body: truncatedBody,
-			});
-			url = `${GITHUB_REPO_URL}/issues/new?${shortParams.toString()}`;
-		}
-
-		return url;
+		return this.buildIssuePayload(snapshot).url;
 	}
 
 	buildTitle(snapshot: DiagnosticsSnapshot): string {
@@ -88,8 +127,11 @@ export class IssueReporter {
 		return "[Bug] Issue report from diagnostics";
 	}
 
-	buildBody(snapshot: DiagnosticsSnapshot): string {
+	buildBody(snapshot: DiagnosticsSnapshot, options: BodyOptions = {}): string {
 		const sections: string[] = [];
+		const recentLogs = options.recentLogs ?? snapshot.recentLogs;
+		const stackMode = options.stackMode ?? "full";
+		const compactedDiagnosticsHint = options.compactedDiagnosticsHint ?? "full diagnostics omitted from URL";
 
 		sections.push("## What happened\n\n<!-- Describe what happened -->\n");
 		sections.push("## Expected behavior\n\n<!-- What did you expect to happen? -->\n");
@@ -122,22 +164,17 @@ export class IssueReporter {
 			diagLines.push(`- Source: ${snapshot.latestError.source}`);
 			diagLines.push(`- Time: ${snapshot.latestError.timestamp}`);
 			diagLines.push(`- Message: ${redactSecrets(snapshot.latestError.message)}`);
-			if (snapshot.latestError.stack) {
-				diagLines.push("");
-				diagLines.push("<details><summary>Stack trace</summary>");
-				diagLines.push("");
-				diagLines.push("```");
-				diagLines.push(redactSecrets(snapshot.latestError.stack));
-				diagLines.push("```");
-				diagLines.push("");
-				diagLines.push("</details>");
-			}
 		}
 		diagLines.push("");
 		sections.push(diagLines.join("\n"));
 
-		if (snapshot.recentLogs.length > 0) {
-			const logLines = snapshot.recentLogs.slice(-20).map((l) => redactSecrets(l));
+		if (recentLogs.length > 0 || options.omittedLogCount) {
+			const logLines = recentLogs.map((l) => redactSecrets(l));
+			if (options.omittedLogCount) {
+				logLines.unshift(
+					`... (${options.omittedLogCount} older log line${options.omittedLogCount === 1 ? "" : "s"} omitted; ${compactedDiagnosticsHint})`
+				);
+			}
 			sections.push(
 				[
 					"## Recent logs",
@@ -154,19 +191,159 @@ export class IssueReporter {
 			);
 		}
 
+		if (snapshot.latestError?.stack) {
+			const stack =
+				stackMode === "compact"
+					? compactStack(snapshot.latestError.stack, compactedDiagnosticsHint)
+					: snapshot.latestError.stack;
+			sections.push(
+				[
+					`<details><summary>${stackMode === "compact" ? "Stack trace (trimmed)" : "Stack trace"}</summary>`,
+					"",
+					"```",
+					redactSecrets(stack),
+					"```",
+					"",
+					"</details>",
+					"",
+				].join("\n")
+			);
+		}
+
 		return sections.join("\n");
 	}
 
 	async openIssue(snapshot: DiagnosticsSnapshot): Promise<void> {
-		const fullBody = this.buildBody(snapshot);
-		const url = this.buildIssueUrl(snapshot);
+		const compactedDiagnosticsHint = this.env.saveDiagnosticsFile
+			? "full diagnostics copied to clipboard and saved to a diagnostics file"
+			: "full diagnostics copied to clipboard";
+		const payload = this.buildIssuePayload(snapshot, compactedDiagnosticsHint);
+		let diagnosticsFile: vscode.Uri | undefined;
 
-		if (fullBody.length > MAX_BODY_LENGTH) {
-			await vscode.env.clipboard.writeText(fullBody);
+		if (payload.compacted) {
+			await this.env.writeClipboard(payload.fullBody);
+			diagnosticsFile = await this.env.saveDiagnosticsFile?.(payload.fullBody);
 		}
 
-		await vscode.env.openExternal(vscode.Uri.parse(url));
+		await this.env.openExternal(vscode.Uri.parse(payload.url));
+
+		if (payload.compacted) {
+			void this.env.showCompactedDiagnosticsMessage?.(diagnosticsFile);
+		}
 	}
+
+	private buildIssuePayload(
+		snapshot: DiagnosticsSnapshot,
+		compactedDiagnosticsHint = "full diagnostics omitted from URL"
+	): IssuePayload {
+		const title = this.buildTitle(snapshot);
+		const fullBody = this.buildBody(snapshot);
+		const fullUrl = createIssueUrl(title, fullBody);
+		if (fullUrl.length <= MAX_URL_LENGTH) {
+			return { url: fullUrl, fullBody, compacted: false };
+		}
+
+		const compactStackBody = this.buildBody(snapshot, { stackMode: "compact", compactedDiagnosticsHint });
+		const compactStackUrl = createIssueUrl(title, compactStackBody);
+		if (compactStackUrl.length <= MAX_URL_LENGTH) {
+			return { url: compactStackUrl, fullBody, compacted: true };
+		}
+
+		for (let omitted = 1; omitted <= snapshot.recentLogs.length; omitted++) {
+			const logs = snapshot.recentLogs.slice(omitted);
+			const body = this.buildBody(snapshot, {
+				recentLogs: logs,
+				omittedLogCount: omitted,
+				stackMode: "compact",
+				compactedDiagnosticsHint,
+			});
+			const url = createIssueUrl(title, body);
+			if (url.length <= MAX_URL_LENGTH) {
+				return { url, fullBody, compacted: true };
+			}
+		}
+
+		const fallbackBody = buildClipboardFallbackBody(snapshot, compactedDiagnosticsHint);
+		return {
+			url: createIssueUrl(title, fallbackBody),
+			fullBody,
+			compacted: true,
+		};
+	}
+}
+
+function createIssueUrl(title: string, body: string): string {
+	const params = new URLSearchParams({
+		labels: "bug",
+		title,
+		body,
+	});
+
+	return `${GITHUB_REPO_URL}/issues/new?${params.toString()}`;
+}
+
+function compactStack(stack: string, compactedDiagnosticsHint: string): string {
+	const lines = stack.split(/\r?\n/);
+	if (lines.length <= COMPACT_STACK_LINES) {
+		return stack;
+	}
+
+	const omitted = lines.length - COMPACT_STACK_LINES;
+	return [
+		...lines.slice(0, COMPACT_STACK_LINES),
+		`... (${omitted} stack line${omitted === 1 ? "" : "s"} omitted; ${compactedDiagnosticsHint})`,
+	].join("\n");
+}
+
+function buildClipboardFallbackBody(snapshot: DiagnosticsSnapshot, compactedDiagnosticsHint: string): string {
+	const lines = [
+		"## What happened",
+		"",
+		"<!-- Describe what happened -->",
+		"",
+		"## Diagnostics",
+		"",
+		`- Connection state: ${snapshot.connectionState}`,
+		snapshot.modelCount !== undefined ? `- Model count: ${snapshot.modelCount}` : null,
+		`- API key configured: ${snapshot.apiKeyConfigured ? "yes" : "no"}`,
+		`- Base URL configured: ${snapshot.baseUrlConfigured ? "yes" : "no"}`,
+	];
+
+	if (snapshot.latestError) {
+		lines.push("", "### Latest error", "");
+		lines.push(`- Source: ${snapshot.latestError.source}`);
+		lines.push(`- Time: ${snapshot.latestError.timestamp}`);
+		lines.push(`- Message: ${shortenLine(redactSecrets(snapshot.latestError.message.split(/\r?\n/)[0]), 500)}`);
+	}
+
+	lines.push(
+		"",
+		`Full redacted diagnostics were too large to prefill in GitHub. ${capitalizeFirst(compactedDiagnosticsHint)}. ${getCompactedDiagnosticsAction(compactedDiagnosticsHint)}`
+	);
+
+	return lines.filter((line): line is string => line !== null).join("\n");
+}
+
+function capitalizeFirst(text: string): string {
+	return text.length === 0 ? text : `${text[0].toUpperCase()}${text.slice(1)}`;
+}
+
+function getCompactedDiagnosticsAction(compactedDiagnosticsHint: string): string {
+	if (compactedDiagnosticsHint.includes("saved to a diagnostics file")) {
+		return "Please attach the generated file or paste the contents here.";
+	}
+	if (compactedDiagnosticsHint.includes("clipboard")) {
+		return "Please paste the copied contents here.";
+	}
+	return "Please add the full diagnostics separately.";
+}
+
+function shortenLine(text: string, maxLength: number): string {
+	if (text.length <= maxLength) {
+		return text;
+	}
+
+	return `${text.slice(0, maxLength)}...`;
 }
 
 export function redactSecrets(text: string): string {

--- a/src/test/issueReporter.test.ts
+++ b/src/test/issueReporter.test.ts
@@ -1,8 +1,11 @@
 import * as assert from "assert";
+import * as vscode from "vscode";
 import { IssueReporter, redactSecrets } from "../issueReporter";
 import type { DiagnosticsSnapshot } from "../issueReporter";
 
 suite("IssueReporter", () => {
+	const MAX_SAFE_URL_LENGTH = 8000;
+
 	function makeSnapshot(overrides?: Partial<DiagnosticsSnapshot>): DiagnosticsSnapshot {
 		return {
 			extensionVersion: "0.2.3",
@@ -15,6 +18,10 @@ suite("IssueReporter", () => {
 			recentLogs: [],
 			...overrides,
 		};
+	}
+
+	function getIssueBody(url: string): string {
+		return new URL(url).searchParams.get("body") ?? "";
 	}
 
 	test("buildIssueUrl produces valid GitHub URL with query params", () => {
@@ -99,6 +106,154 @@ suite("IssueReporter", () => {
 		);
 		assert.ok(body.includes("## Recent logs"));
 		assert.ok(body.includes("Fetching models"));
+	});
+
+	test("buildBody keeps recent logs before stack trace", () => {
+		const reporter = new IssueReporter();
+		const body = reporter.buildBody(
+			makeSnapshot({
+				latestError: {
+					source: "fetchModels",
+					message: "network failure",
+					stack: "Error: network failure\n    at fetchModels.ts:1",
+					timestamp: "2026-01-01T00:00:00.000Z",
+				},
+				recentLogs: ["[2026-01-01] ERROR: Failed to fetch models from server Default"],
+			})
+		);
+
+		assert.ok(body.indexOf("## Recent logs") < body.indexOf("Stack trace"));
+		assert.ok(body.includes("[2026-01-01] ERROR: Failed to fetch models from server Default"));
+	});
+
+	test("buildBody includes all buffered recent logs", () => {
+		const reporter = new IssueReporter();
+		const recentLogs = Array.from({ length: 25 }, (_, i) => `line ${i}`);
+		const body = reporter.buildBody(makeSnapshot({ recentLogs }));
+
+		assert.ok(body.includes("line 0"));
+		assert.ok(body.includes("line 24"));
+	});
+
+	test("buildIssueUrl does not truncate realistic diagnostics", () => {
+		const reporter = new IssueReporter();
+		const finalLog = '[2026-06-05T01:22:21.281Z] ERROR: Failed to fetch models from server "Default": fetch failed';
+		const url = reporter.buildIssueUrl(
+			makeSnapshot({
+				connectionState: "error",
+				modelCount: 0,
+				latestError: {
+					source: 'Failed to fetch models from server "Default"',
+					message: "Network Error: Failed to fetch models from https://internal.example.com/v1/models fetch failed",
+					stack: [
+						"Error: Network Error: Failed to fetch models from https://internal.example.com/v1/models fetch failed",
+						"    at fetchModels (c:\\Users\\user\\.vscode\\extensions\\vivswan.litellm-vscode-chat-0.2.6\\out\\provider\\discovery.js:166:25)",
+						"    at processTicksAndRejections (node:internal/process/task_queues:104:5)",
+						"    at LiteLLMChatModelProvider.prepareLanguageModelChatInformation (c:\\Users\\user\\.vscode\\extensions\\vivswan.litellm-vscode-chat-0.2.6\\out\\provider.js:119:25)",
+					].join("\n"),
+					timestamp: "2026-06-05T01:22:23.326Z",
+				},
+				recentLogs: [
+					"[2026-06-05T01:22:20.000Z] prepareLanguageModelChatInformation called",
+					"[2026-06-05T01:22:20.500Z] Fetching models from servers",
+					finalLog,
+				],
+			})
+		);
+		const body = getIssueBody(url);
+
+		assert.ok(url.length <= MAX_SAFE_URL_LENGTH);
+		assert.ok(body.includes(finalLog));
+		assert.ok(!body.includes("...(truncated)"));
+		assert.ok(!body.includes("full diagnostics copied to clipboard"));
+	});
+
+	test("buildIssueUrl drops oldest logs as whole lines when the report is too large", () => {
+		const reporter = new IssueReporter();
+		const logs = Array.from({ length: 50 }, (_, i) => `log ${i.toString().padStart(2, "0")} ${"x".repeat(140)}`);
+		const url = reporter.buildIssueUrl(
+			makeSnapshot({
+				latestError: {
+					source: "fetchModels",
+					message: "network failure",
+					stack: Array.from({ length: 40 }, (_, i) => `    at frame${i} (file${i}.ts:1:1)`).join("\n"),
+					timestamp: "2026-01-01T00:00:00.000Z",
+				},
+				recentLogs: logs,
+			})
+		);
+		const body = getIssueBody(url);
+
+		assert.ok(url.length <= MAX_SAFE_URL_LENGTH);
+		assert.ok(body.includes("older log lines omitted"));
+		assert.ok(!body.includes(logs[0]));
+		assert.ok(body.includes(logs[49]));
+		assert.ok(!body.includes("...(truncated)"));
+	});
+
+	test("openIssue copies full diagnostics when the URL body is compacted", async () => {
+		let clipboardText: string | undefined;
+		let savedText: string | undefined;
+		let notifiedFile: vscode.Uri | undefined;
+		let openedUri: string | undefined;
+		const diagnosticsFile = vscode.Uri.file("/tmp/litellm-diagnostics.md");
+		const reporter = new IssueReporter({
+			writeClipboard: async (text) => {
+				clipboardText = text;
+			},
+			saveDiagnosticsFile: async (text) => {
+				savedText = text;
+				return diagnosticsFile;
+			},
+			openExternal: async (uri) => {
+				openedUri = uri.toString(true);
+				return true;
+			},
+			showCompactedDiagnosticsMessage: async (file) => {
+				notifiedFile = file;
+			},
+		});
+		const logs = Array.from({ length: 50 }, (_, i) => `log ${i.toString().padStart(2, "0")} ${"x".repeat(140)}`);
+
+		await reporter.openIssue(
+			makeSnapshot({
+				latestError: {
+					source: "fetchModels",
+					message: "network failure",
+					stack: Array.from({ length: 40 }, (_, i) => `    at frame${i} (file${i}.ts:1:1)`).join("\n"),
+					timestamp: "2026-01-01T00:00:00.000Z",
+				},
+				recentLogs: logs,
+			})
+		);
+
+		assert.ok(openedUri);
+		assert.ok(openedUri.length <= MAX_SAFE_URL_LENGTH);
+		assert.ok(clipboardText?.includes(logs[0]));
+		assert.ok(clipboardText?.includes(logs[49]));
+		assert.equal(savedText, clipboardText);
+		assert.equal(notifiedFile?.toString(), diagnosticsFile.toString());
+		assert.ok(getIssueBody(openedUri).includes("saved to a diagnostics file"));
+	});
+
+	test("buildIssueUrl final fallback stays short for huge messages", () => {
+		const reporter = new IssueReporter();
+		const url = reporter.buildIssueUrl(
+			makeSnapshot({
+				latestError: {
+					source: "fetchModels",
+					message: `network failure ${"x".repeat(30000)}`,
+					timestamp: "2026-01-01T00:00:00.000Z",
+				},
+				recentLogs: [],
+			})
+		);
+		const body = getIssueBody(url);
+
+		assert.ok(url.length <= MAX_SAFE_URL_LENGTH);
+		assert.ok(body.includes("Full redacted diagnostics were too large to prefill in GitHub"));
+		assert.ok(body.includes("Please add the full diagnostics separately"));
+		assert.ok(!body.includes("x".repeat(1000)));
 	});
 
 	test("appendLog maintains rolling buffer", () => {


### PR DESCRIPTION
## Summary
- Remove the hard 1,500-character issue body truncation and compact diagnostics based on encoded GitHub URL length
- Preserve recent logs ahead of stack traces and omit old log lines only as whole lines when needed
- Save oversized full redacted diagnostics to a generated markdown file, copy them to clipboard, and prompt users to attach or paste them

## Validation
- `bunx prettier --write src/issueReporter.ts src/test/issueReporter.test.ts src/extension.ts`
- `bun run compile`
- `bun run lint:actions`
- `bun run lint`
- `bun run test`