### PR TITLE
feat: add pricing metadata and live cost tracking

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,9 @@ export function activate(context: vscode.ExtensionContext) {
 	provider.setStatusCallback((aggStatus: AggregatedStatus) => {
 		statusBar.handleAggregatedStatus(aggStatus);
 	});
+	provider.setResponseCostCallback((cost) => {
+		statusBar.addSessionCost(cost);
+	});
 
 	// Welcome message
 	const hasShownWelcome = context.globalState.get<boolean>("litellm.hasShownWelcome", false);

--- a/src/extension/status.ts
+++ b/src/extension/status.ts
@@ -13,6 +13,7 @@ export interface ConnectionStatus {
 export class StatusBarManager {
 	private _connectionStatus: ConnectionStatus = { state: "not-configured" };
 	private readonly _statusBarItem: vscode.StatusBarItem;
+	private _sessionCostUsd = 0;
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
@@ -33,6 +34,30 @@ export class StatusBarManager {
 		return this._connectionStatus;
 	}
 
+	addSessionCost(costUsd: number): void {
+		if (!Number.isFinite(costUsd) || costUsd <= 0) {
+			return;
+		}
+		this._sessionCostUsd += costUsd;
+		void this.updateStatusBar();
+	}
+
+	private costSuffix(): string {
+		if (this._sessionCostUsd <= 0) {
+			return "";
+		}
+		const formatted = this._sessionCostUsd < 0.0001 ? "<0.0001" : this._sessionCostUsd.toFixed(4);
+		return ` - $${formatted}`;
+	}
+
+	private costTooltipSuffix(): string {
+		if (this._sessionCostUsd <= 0) {
+			return "";
+		}
+		const formatted = this._sessionCostUsd < 0.0001 ? "<0.0001" : this._sessionCostUsd.toFixed(4);
+		return `\nCumulative LiteLLM cost since this window started: $${formatted}`;
+	}
+
 	async updateStatusBar(status?: ConnectionStatus): Promise<void> {
 		if (status) {
 			this._connectionStatus = status;
@@ -41,21 +66,21 @@ export class StatusBarManager {
 
 		switch (this._connectionStatus.state) {
 			case "not-configured":
-				this._statusBarItem.text = "$(warning) LiteLLM";
-				this._statusBarItem.tooltip = "Not configured - click to set up";
+				this._statusBarItem.text = `$(warning) LiteLLM${this.costSuffix()}`;
+				this._statusBarItem.tooltip = `Not configured - click to set up${this.costTooltipSuffix()}`;
 				this._statusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
 				break;
 			case "loading":
-				this._statusBarItem.text = "$(loading~spin) LiteLLM";
-				this._statusBarItem.tooltip = "Fetching models...";
+				this._statusBarItem.text = `$(loading~spin) LiteLLM${this.costSuffix()}`;
+				this._statusBarItem.tooltip = `Fetching models...${this.costTooltipSuffix()}`;
 				this._statusBarItem.backgroundColor = undefined;
 				break;
 			case "connected": {
 				const count = this._connectionStatus.totalModels ?? 0;
 				const serverCount = this._connectionStatus.serverStatuses?.length ?? 0;
 				const serverText = serverCount > 1 ? ` from ${serverCount} servers` : "";
-				this._statusBarItem.text = `$(check) LiteLLM (${count})`;
-				this._statusBarItem.tooltip = `${count} model${count === 1 ? "" : "s"} available${serverText}\nClick for diagnostics`;
+				this._statusBarItem.text = `$(check) LiteLLM (${count})${this.costSuffix()}`;
+				this._statusBarItem.tooltip = `${count} model${count === 1 ? "" : "s"} available${serverText}\nClick for diagnostics${this.costTooltipSuffix()}`;
 				this._statusBarItem.backgroundColor = undefined;
 				break;
 			}
@@ -63,14 +88,14 @@ export class StatusBarManager {
 				const count = this._connectionStatus.totalModels ?? 0;
 				const statuses = this._connectionStatus.serverStatuses ?? [];
 				const failedCount = statuses.filter((s) => s.state === "error").length;
-				this._statusBarItem.text = `$(warning) LiteLLM (${count})`;
-				this._statusBarItem.tooltip = `${count} model${count === 1 ? "" : "s"} available\n${failedCount} server${failedCount === 1 ? "" : "s"} unreachable\nClick for diagnostics`;
+				this._statusBarItem.text = `$(warning) LiteLLM (${count})${this.costSuffix()}`;
+				this._statusBarItem.tooltip = `${count} model${count === 1 ? "" : "s"} available\n${failedCount} server${failedCount === 1 ? "" : "s"} unreachable\nClick for diagnostics${this.costTooltipSuffix()}`;
 				this._statusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.warningBackground");
 				break;
 			}
 			case "error":
-				this._statusBarItem.text = "$(error) LiteLLM";
-				this._statusBarItem.tooltip = `Connection failed\n${this._connectionStatus.error || "Unknown error"}\nClick for details`;
+				this._statusBarItem.text = `$(error) LiteLLM${this.costSuffix()}`;
+				this._statusBarItem.tooltip = `Connection failed\n${this._connectionStatus.error || "Unknown error"}\nClick for details${this.costTooltipSuffix()}`;
 				this._statusBarItem.backgroundColor = new vscode.ThemeColor("statusBarItem.errorBackground");
 				break;
 		}

--- a/src/extension/status.ts
+++ b/src/extension/status.ts
@@ -10,6 +10,13 @@ export interface ConnectionStatus {
 	lastChecked?: string;
 }
 
+export function formatSessionCostUsd(costUsd: number): string | undefined {
+	if (!Number.isFinite(costUsd) || costUsd <= 0) {
+		return undefined;
+	}
+	return costUsd < 0.0001 ? "<$0.0001" : `$${costUsd.toFixed(4)}`;
+}
+
 export class StatusBarManager {
 	private _connectionStatus: ConnectionStatus = { state: "not-configured" };
 	private readonly _statusBarItem: vscode.StatusBarItem;
@@ -43,19 +50,19 @@ export class StatusBarManager {
 	}
 
 	private costSuffix(): string {
-		if (this._sessionCostUsd <= 0) {
+		const formatted = formatSessionCostUsd(this._sessionCostUsd);
+		if (!formatted) {
 			return "";
 		}
-		const formatted = this._sessionCostUsd < 0.0001 ? "<0.0001" : this._sessionCostUsd.toFixed(4);
-		return ` - $${formatted}`;
+		return ` - ${formatted}`;
 	}
 
 	private costTooltipSuffix(): string {
-		if (this._sessionCostUsd <= 0) {
+		const formatted = formatSessionCostUsd(this._sessionCostUsd);
+		if (!formatted) {
 			return "";
 		}
-		const formatted = this._sessionCostUsd < 0.0001 ? "<0.0001" : this._sessionCostUsd.toFixed(4);
-		return `\nCumulative LiteLLM cost since this window started: $${formatted}`;
+		return `\nCumulative LiteLLM cost since this window started: ${formatted}`;
 	}
 
 	async updateStatusBar(status?: ConnectionStatus): Promise<void> {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -27,6 +27,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 	private _chatEndpoints: { model: string; modelMaxPromptTokens: number }[] = [];
 	private _promptCachingSupport = new Map<string, boolean>();
 	private _statusCallback?: (status: AggregatedStatus) => void;
+	private _responseCostCallback?: (cost: number) => void;
 	private _hasShownNoConfigNotification = false;
 	private _toolCallIdCounter = 0;
 	private _modelRoutes = new Map<string, ModelRoute>();
@@ -41,6 +42,10 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 
 	setStatusCallback(callback: (status: AggregatedStatus) => void): void {
 		this._statusCallback = callback;
+	}
+
+	setResponseCostCallback(callback: (cost: number) => void): void {
+		this._responseCostCallback = callback;
 	}
 
 	setServerProvider(getServers: () => Promise<ServerWithKey[]>): void {
@@ -260,6 +265,7 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 				this.secrets,
 				this.userAgent,
 				this._toolCallIdCounter,
+				(cost) => this._responseCostCallback?.(cost),
 				(msg, data) => this.log(msg, data),
 				(msg, err) => this.logError(msg, err)
 			);

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -12,6 +12,7 @@ import type { ModelRoute } from "./request";
 import { StreamProcessor } from "./streaming";
 import { resolveServer } from "./config";
 import type { ServerWithKey } from "../extension/serverRegistry";
+import { getHeaderCost, ResponseCostTracker } from "./cost";
 
 export interface ChatRequestContext {
 	model: LanguageModelChatInformation;
@@ -29,6 +30,7 @@ export async function sendChatRequest(
 	secrets: vscode.SecretStorage,
 	userAgent: string,
 	toolCallIdCounter: number,
+	onResponseCost: (cost: number) => void,
 	log: (message: string, data?: unknown) => void,
 	logError: (message: string, error: unknown) => void
 ): Promise<number> {
@@ -147,7 +149,21 @@ export async function sendChatRequest(
 		throw new Error("No response body from LiteLLM API");
 	}
 
-	const streamProcessor = new StreamProcessor(toolCallIdCounter, log);
-	await streamProcessor.processStreamingResponse(response.body, progress, token);
+	const costTracker = new ResponseCostTracker({
+		inputCostPerToken: route?.inputCostPerToken,
+		outputCostPerToken: route?.outputCostPerToken,
+	});
+	costTracker.addHeaderCost(getHeaderCost(response));
+
+	const streamProcessor = new StreamProcessor(toolCallIdCounter, log, costTracker);
+	try {
+		await streamProcessor.processStreamingResponse(response.body, progress, token);
+	} finally {
+		const finalizedCost = costTracker.finalize();
+		if (finalizedCost && finalizedCost.costUsd > 0) {
+			log("LiteLLM response cost finalized", finalizedCost);
+			onResponseCost(finalizedCost.costUsd);
+		}
+	}
 	return streamProcessor.toolCallIdCounter;
 }

--- a/src/provider/cost.ts
+++ b/src/provider/cost.ts
@@ -1,0 +1,127 @@
+import { normalizeNonNegativeNumber } from "../shared/numbers";
+
+export interface TokenPricing {
+	inputCostPerToken?: number;
+	outputCostPerToken?: number;
+}
+
+export interface FinalizedResponseCost {
+	costUsd: number;
+	source: "stream" | "header" | "computed";
+	estimated: boolean;
+}
+
+interface CostCandidate extends FinalizedResponseCost {
+	priority: number;
+}
+
+const STREAM_PRIORITY = 3;
+const HEADER_PRIORITY = 2;
+const COMPUTED_PRIORITY = 1;
+
+export function formatCostPerMillionTokens(costPerToken: unknown): string | undefined {
+	const normalized = normalizeNonNegativeNumber(costPerToken);
+	if (normalized === undefined) {
+		return undefined;
+	}
+	return `$${(normalized * 1_000_000).toFixed(2)}/M`;
+}
+
+export function formatTokenPricing(inputCostPerToken: unknown, outputCostPerToken: unknown): string | undefined {
+	const parts: string[] = [];
+	const input = formatCostPerMillionTokens(inputCostPerToken);
+	const output = formatCostPerMillionTokens(outputCostPerToken);
+
+	if (input) {
+		parts.push(`Input ${input}`);
+	}
+	if (output) {
+		parts.push(`Output ${output}`);
+	}
+
+	return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+export function getHeaderCost(response: Response): unknown {
+	const headers = (response as Response & { headers?: { get?: (name: string) => string | null } }).headers;
+	return headers?.get?.("x-litellm-response-cost") ?? undefined;
+}
+
+function firstCostCandidate(values: unknown[]): unknown {
+	return values.find((value) => value !== undefined && value !== null);
+}
+
+export class ResponseCostTracker {
+	private _candidate?: CostCandidate;
+
+	constructor(private readonly pricing: TokenPricing = {}) {}
+
+	addHeaderCost(value: unknown): void {
+		this.record(value, "header", false, HEADER_PRIORITY);
+	}
+
+	addStreamCost(value: unknown): void {
+		this.record(value, "stream", false, STREAM_PRIORITY);
+	}
+
+	addUsage(usage: Record<string, unknown>): void {
+		const explicitCost = firstCostCandidate([usage.response_cost, usage.cost, usage.total_cost]);
+		if (explicitCost !== undefined) {
+			this.addStreamCost(explicitCost);
+			return;
+		}
+
+		const promptTokens = normalizeNonNegativeNumber(usage.prompt_tokens ?? usage.input_tokens);
+		const completionTokens = normalizeNonNegativeNumber(usage.completion_tokens ?? usage.output_tokens);
+		const inputCost = this.pricing.inputCostPerToken ?? 0;
+		const outputCost = this.pricing.outputCostPerToken ?? 0;
+
+		if (inputCost === 0 && outputCost === 0) {
+			return;
+		}
+
+		let cost = 0;
+		let hasBillableTokens = false;
+		if (promptTokens !== undefined && inputCost > 0) {
+			cost += promptTokens * inputCost;
+			hasBillableTokens = true;
+		}
+		if (completionTokens !== undefined && outputCost > 0) {
+			cost += completionTokens * outputCost;
+			hasBillableTokens = true;
+		}
+
+		if (hasBillableTokens) {
+			this.record(cost, "computed", true, COMPUTED_PRIORITY);
+		}
+	}
+
+	addDelta(delta: Record<string, unknown>): void {
+		const usage = delta.usage;
+		if (usage && typeof usage === "object" && !Array.isArray(usage)) {
+			this.addUsage(usage as Record<string, unknown>);
+		}
+
+		this.addStreamCost(
+			firstCostCandidate([delta.response_cost, (delta as Record<string, unknown>)["x-litellm-response-cost"]])
+		);
+	}
+
+	finalize(): FinalizedResponseCost | undefined {
+		if (!this._candidate) {
+			return undefined;
+		}
+		const { costUsd, source, estimated } = this._candidate;
+		return { costUsd, source, estimated };
+	}
+
+	private record(value: unknown, source: FinalizedResponseCost["source"], estimated: boolean, priority: number): void {
+		const costUsd = normalizeNonNegativeNumber(value);
+		if (costUsd === undefined) {
+			return;
+		}
+		if (!this._candidate || priority >= this._candidate.priority) {
+			this._candidate = { costUsd, source, estimated, priority };
+		}
+	}
+}

--- a/src/provider/cost.ts
+++ b/src/provider/cost.ts
@@ -47,8 +47,14 @@ export function getHeaderCost(response: Response): unknown {
 	return headers?.get?.("x-litellm-response-cost") ?? undefined;
 }
 
-function firstCostCandidate(values: unknown[]): unknown {
-	return values.find((value) => value !== undefined && value !== null);
+function firstCostCandidate(values: unknown[]): number | undefined {
+	for (const value of values) {
+		const normalized = normalizeNonNegativeNumber(value);
+		if (normalized !== undefined) {
+			return normalized;
+		}
+	}
+	return undefined;
 }
 
 export class ResponseCostTracker {

--- a/src/provider/discovery.ts
+++ b/src/provider/discovery.ts
@@ -5,7 +5,7 @@ import type {
 	LiteLLMModelsResponse,
 	LiteLLMProvider,
 } from "../types";
-import { normalizePositiveNumber } from "../shared/numbers";
+import { normalizeNonNegativeNumber, normalizePositiveNumber } from "../shared/numbers";
 
 export function mapModelInfoToLiteLLMModel(item: LiteLLMModelInfoItem): LiteLLMModelItem | undefined {
 	const modelId = item.model_name ?? item.litellm_params?.model ?? item.model_info?.key ?? item.model_info?.id;
@@ -30,6 +30,8 @@ export function mapModelInfoToLiteLLMModel(item: LiteLLMModelInfoItem): LiteLLMM
 		max_tokens: maxTokens,
 		max_input_tokens: maxInputTokens,
 		max_output_tokens: maxOutputTokens,
+		input_cost_per_token: normalizeNonNegativeNumber(item.model_info?.input_cost_per_token),
+		output_cost_per_token: normalizeNonNegativeNumber(item.model_info?.output_cost_per_token),
 		source: "model_info",
 		supports_prompt_caching: item.model_info?.supports_prompt_caching ?? null,
 		supports_response_schema: item.model_info?.supports_response_schema ?? null,

--- a/src/provider/registration.ts
+++ b/src/provider/registration.ts
@@ -3,6 +3,8 @@ import type { LiteLLMModelItem } from "../types";
 import type { ServerWithKey } from "../extension/serverRegistry";
 import type { ModelRoute } from "./request";
 import { getTokenConstraints, buildExposedModelId } from "./request";
+import { normalizeNonNegativeNumber } from "../shared/numbers";
+import { formatTokenPricing } from "./cost";
 
 export interface RegistrationResult {
 	infos: LanguageModelChatInformation[];
@@ -32,11 +34,26 @@ export function buildModelInfos(
 	const routes = new Map<string, ModelRoute>();
 	const promptCaching = new Map<string, boolean>();
 
-	const registerRoute = (exposedId: string, rawId: string) => {
+	const providerPricing = (provider: LiteLLMModelItem["providers"][number]): string | undefined =>
+		formatTokenPricing(provider.input_cost_per_token, provider.output_cost_per_token);
+
+	const pricedDetail = (fallback: string, provider: LiteLLMModelItem["providers"][number]): string => {
+		const pricing = providerPricing(provider);
+		return pricing ? `${pricing} (${fallback})` : fallback;
+	};
+
+	const pricedTooltip = (title: string, provider: LiteLLMModelItem["providers"][number]): string => {
+		const pricing = providerPricing(provider);
+		return pricing ? `${title}\nPricing: ${pricing}` : title;
+	};
+
+	const registerRoute = (exposedId: string, rawId: string, provider?: LiteLLMModelItem["providers"][number]) => {
 		routes.set(exposedId, {
 			serverId: server.id,
 			rawModelId: rawId,
 			serverLabel: server.label,
+			inputCostPerToken: normalizeNonNegativeNumber(provider?.input_cost_per_token),
+			outputCostPerToken: normalizeNonNegativeNumber(provider?.output_cost_per_token),
 		});
 	};
 
@@ -52,13 +69,13 @@ export function buildModelInfos(
 			const constraints = getTokenConstraints(providers[0]);
 			const exposedId = buildExposedModelId(m.id, server.id, serverCount);
 			promptCaching.set(exposedId, providers[0].supports_prompt_caching === true);
-			registerRoute(exposedId, m.id);
+			registerRoute(exposedId, m.id, providers[0]);
 			return [
 				{
 					id: exposedId,
 					name: `${namePrefix}${m.id}`,
-					detail,
-					tooltip: serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM",
+					detail: pricedDetail(detail, providers[0]),
+					tooltip: pricedTooltip(serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM", providers[0]),
 					family: "litellm",
 					version: "1.0.0",
 					maxInputTokens: constraints.maxInputTokens,
@@ -149,8 +166,8 @@ export function buildModelInfos(
 			entries.push({
 				id: exposedId,
 				name: `${namePrefix}${m.id} via ${p.provider}`,
-				detail,
-				tooltip: `LiteLLM via ${p.provider}${serverCount > 1 ? ` on ${server.label}` : ""}`,
+				detail: pricedDetail(detail, p),
+				tooltip: pricedTooltip(`LiteLLM via ${p.provider}${serverCount > 1 ? ` on ${server.label}` : ""}`, p),
 				family: "litellm",
 				version: "1.0.0",
 				maxInputTokens: constraints.maxInputTokens,
@@ -161,7 +178,7 @@ export function buildModelInfos(
 				},
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, p.supports_prompt_caching === true);
-			registerRoute(exposedId, rawId);
+			registerRoute(exposedId, rawId, p);
 		}
 
 		if (toolProviders.length === 0 && providers.length > 0) {
@@ -171,8 +188,8 @@ export function buildModelInfos(
 			entries.push({
 				id: exposedId,
 				name: `${namePrefix}${m.id}`,
-				detail,
-				tooltip: serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM",
+				detail: pricedDetail(detail, base),
+				tooltip: pricedTooltip(serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM", base),
 				family: "litellm",
 				version: "1.0.0",
 				maxInputTokens: constraints.maxInputTokens,
@@ -183,7 +200,7 @@ export function buildModelInfos(
 				},
 			} satisfies LanguageModelChatInformation);
 			promptCaching.set(exposedId, base.supports_prompt_caching === true);
-			registerRoute(exposedId, m.id);
+			registerRoute(exposedId, m.id, base);
 		}
 
 		return entries;

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -10,6 +10,8 @@ export interface ModelRoute {
 	serverId: string;
 	rawModelId: string;
 	serverLabel: string;
+	inputCostPerToken?: number;
+	outputCostPerToken?: number;
 }
 
 export function getTokenConstraints(provider: LiteLLMProvider | undefined): {

--- a/src/provider/streaming.ts
+++ b/src/provider/streaming.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { tryParseJSONObject } from "../shared/json";
+import type { ResponseCostTracker } from "./cost";
 
 interface RequestState {
 	toolCallBuffers: Map<number, { id?: string; name?: string; args: string }>;
@@ -30,7 +31,11 @@ export class StreamProcessor {
 	private _toolCallIdCounter: number;
 	private _log: (message: string, data?: unknown) => void;
 
-	constructor(initialIdCounter: number, log: (message: string, data?: unknown) => void) {
+	constructor(
+		initialIdCounter: number,
+		log: (message: string, data?: unknown) => void,
+		private readonly costTracker?: ResponseCostTracker
+	) {
 		this._req = freshRequestState();
 		this._toolCallIdCounter = initialIdCounter;
 		this._log = log;
@@ -99,6 +104,7 @@ export class StreamProcessor {
 		if (usage) {
 			this._log("Token usage", usage);
 		}
+		this.costTracker?.addDelta(delta);
 
 		const choice = (delta.choices as Record<string, unknown>[] | undefined)?.[0];
 		if (!choice) {

--- a/src/shared/numbers.ts
+++ b/src/shared/numbers.ts
@@ -4,3 +4,10 @@ export function normalizePositiveNumber(value: unknown): number | undefined {
 
 	return Number.isFinite(candidate) && Number.isInteger(candidate) && candidate > 0 ? candidate : undefined;
 }
+
+export function normalizeNonNegativeNumber(value: unknown): number | undefined {
+	const candidate =
+		typeof value === "number" ? value : typeof value === "string" && value.trim() !== "" ? Number(value) : Number.NaN;
+
+	return Number.isFinite(candidate) && candidate >= 0 ? candidate : undefined;
+}

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -2,7 +2,8 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { LiteLLMChatModelProvider } from "../provider";
 import type { AggregatedStatus } from "../provider";
-import { getModelParameters } from "../provider/request";
+import { ResponseCostTracker, formatTokenPricing } from "../provider/cost";
+import { getModelParameters, type ModelRoute } from "../provider/request";
 
 suite("provider", () => {
 	test("prepareLanguageModelChatInformation returns array (no key -> empty)", async () => {
@@ -731,6 +732,32 @@ suite("provider", () => {
 		});
 	});
 
+	suite("pricing", () => {
+		test("formats per-token pricing as per-million-token display text", () => {
+			assert.equal(formatTokenPricing(2e-7, "5e-7"), "Input $0.20/M, Output $0.50/M");
+			assert.equal(formatTokenPricing(undefined, 0), "Output $0.00/M");
+			assert.equal(formatTokenPricing(-1, Number.NaN), undefined);
+		});
+
+		test("response cost tracker prefers streamed cost over header and de-dupes usage chunks", () => {
+			const tracker = new ResponseCostTracker({ inputCostPerToken: 0.001, outputCostPerToken: 0.002 });
+
+			tracker.addHeaderCost("0.03");
+			tracker.addUsage({ response_cost: 0.04 });
+			tracker.addUsage({ response_cost: 0.05 });
+
+			assert.deepEqual(tracker.finalize(), { costUsd: 0.05, source: "stream", estimated: false });
+		});
+
+		test("response cost tracker computes an estimated fallback from usage and route pricing", () => {
+			const tracker = new ResponseCostTracker({ inputCostPerToken: 0.001, outputCostPerToken: 0.002 });
+
+			tracker.addUsage({ prompt_tokens: 10, completion_tokens: 5 });
+
+			assert.deepEqual(tracker.finalize(), { costUsd: 0.02, source: "computed", estimated: true });
+		});
+	});
+
 	suite("request body construction", () => {
 		function createConfiguredProvider(): LiteLLMChatModelProvider {
 			return new LiteLLMChatModelProvider(
@@ -756,6 +783,16 @@ suite("provider", () => {
 
 		function sseStream(text: string): ReadableStream<Uint8Array> {
 			const chunk = `data: ${JSON.stringify({ choices: [{ delta: { content: text }, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`;
+			return new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode(chunk));
+					controller.close();
+				},
+			});
+		}
+
+		function sseFromPayloads(payloads: Record<string, unknown>[]): ReadableStream<Uint8Array> {
+			const chunk = `${payloads.map((payload) => `data: ${JSON.stringify(payload)}\n\n`).join("")}data: [DONE]\n\n`;
 			return new ReadableStream({
 				start(controller) {
 					controller.enqueue(new TextEncoder().encode(chunk));
@@ -817,6 +854,15 @@ suite("provider", () => {
 			assert.deepEqual(body.response_format, { type: "json_object" });
 			assert.equal(body.reasoning_effort, "high");
 			assert.equal(body.top_k, 50);
+		});
+
+		test("keeps broad pass-through for arbitrary modelOptions", async () => {
+			const body = await captureRequestBody(createConfiguredProvider(), modelInfo, {
+				toolMode: vscode.LanguageModelChatToolMode.Auto,
+				modelOptions: { seed: 123, provider_specific_option: { enabled: true } },
+			});
+			assert.equal(body.seed, 123);
+			assert.deepEqual(body.provider_specific_option, { enabled: true });
 		});
 
 		test("does not overwrite provider-owned fields from modelOptions", async () => {
@@ -927,6 +973,73 @@ suite("provider", () => {
 				assert.strictEqual(body.top_p, 0.8);
 			} finally {
 				vscode.workspace.getConfiguration = originalGetConfig;
+			}
+		});
+
+		test("reports header response cost once when no streamed cost is present", async () => {
+			const originalFetch = global.fetch;
+			const provider = createConfiguredProvider();
+			const costs: number[] = [];
+			provider.setResponseCostCallback((cost) => costs.push(cost));
+			global.fetch = async () =>
+				({
+					ok: true,
+					headers: new Headers({ "x-litellm-response-cost": "0.12" }),
+					body: sseStream("ok"),
+				}) as unknown as Response;
+
+			try {
+				await provider.provideLanguageModelChatResponse(
+					modelInfo,
+					[
+						{
+							role: vscode.LanguageModelChatMessageRole.User,
+							content: [new vscode.LanguageModelTextPart("test")],
+							name: undefined,
+						},
+					],
+					{ toolMode: vscode.LanguageModelChatToolMode.Auto },
+					{ report: () => {} },
+					new vscode.CancellationTokenSource().token
+				);
+				assert.deepEqual(costs, [0.12]);
+			} finally {
+				global.fetch = originalFetch;
+			}
+		});
+
+		test("prefers streamed response cost over header and reports it once", async () => {
+			const originalFetch = global.fetch;
+			const provider = createConfiguredProvider();
+			const costs: number[] = [];
+			provider.setResponseCostCallback((cost) => costs.push(cost));
+			global.fetch = async () =>
+				({
+					ok: true,
+					headers: new Headers({ "x-litellm-response-cost": "0.12" }),
+					body: sseFromPayloads([
+						{ choices: [{ delta: { content: "ok" } }], usage: { response_cost: 0.2 } },
+						{ choices: [], usage: { response_cost: 0.25 } },
+					]),
+				}) as unknown as Response;
+
+			try {
+				await provider.provideLanguageModelChatResponse(
+					modelInfo,
+					[
+						{
+							role: vscode.LanguageModelChatMessageRole.User,
+							content: [new vscode.LanguageModelTextPart("test")],
+							name: undefined,
+						},
+					],
+					{ toolMode: vscode.LanguageModelChatToolMode.Auto },
+					{ report: () => {} },
+					new vscode.CancellationTokenSource().token
+				);
+				assert.deepEqual(costs, [0.25]);
+			} finally {
+				global.fetch = originalFetch;
 			}
 		});
 	});
@@ -1399,6 +1512,56 @@ suite("provider", () => {
 			const modelEntry = infos.find((i) => i.id === "gpt-4o");
 			assert.ok(modelEntry);
 			assert.equal(modelEntry.capabilities.imageInput, true);
+		});
+
+		test("model/info pricing metadata is surfaced in picker detail and route metadata", async () => {
+			const originalFetch = global.fetch;
+			try {
+				global.fetch = async () =>
+					({
+						ok: true,
+						json: async () => ({
+							data: [
+								{
+									model_name: "priced-model",
+									model_info: {
+										id: "priced-model",
+										supports_function_calling: true,
+										max_tokens: 8000,
+										max_input_tokens: 100000,
+										max_output_tokens: 8000,
+										input_cost_per_token: 2e-7,
+										output_cost_per_token: "5e-7",
+									},
+								},
+							],
+						}),
+					}) as unknown as Response;
+
+				const provider = new LiteLLMChatModelProvider(
+					{
+						get: async (key: string) => (key === "litellm.baseUrl" ? "http://test" : "test-key"),
+						store: async () => {},
+						delete: async () => {},
+						onDidChange: (_listener: unknown) => ({ dispose() {} }),
+					} as unknown as vscode.SecretStorage,
+					"GitHubCopilotChat/test VSCode/test"
+				);
+				const infos = await provider.prepareLanguageModelChatInformation(
+					{ silent: true },
+					new vscode.CancellationTokenSource().token
+				);
+
+				const modelEntry = infos.find((i) => i.id === "priced-model");
+				assert.ok(modelEntry);
+				assert.ok(modelEntry.detail?.includes("Input $0.20/M, Output $0.50/M"));
+				assert.ok(modelEntry.tooltip?.includes("Pricing: Input $0.20/M, Output $0.50/M"));
+				const routes = (provider as unknown as { _modelRoutes: Map<string, ModelRoute> })._modelRoutes;
+				assert.equal(routes.get("priced-model")?.inputCostPerToken, 2e-7);
+				assert.equal(routes.get("priced-model")?.outputCostPerToken, 5e-7);
+			} finally {
+				global.fetch = originalFetch;
+			}
 		});
 	});
 });

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { LiteLLMChatModelProvider } from "../provider";
 import type { AggregatedStatus } from "../provider";
+import { formatSessionCostUsd } from "../extension/status";
 import { ResponseCostTracker, formatTokenPricing } from "../provider/cost";
 import { getModelParameters, type ModelRoute } from "../provider/request";
 
@@ -749,12 +750,26 @@ suite("provider", () => {
 			assert.deepEqual(tracker.finalize(), { costUsd: 0.05, source: "stream", estimated: false });
 		});
 
+		test("response cost tracker skips invalid explicit costs when selecting fallback candidates", () => {
+			const tracker = new ResponseCostTracker();
+
+			tracker.addUsage({ response_cost: Number.NaN, cost: "0.03", total_cost: 0.04 });
+
+			assert.deepEqual(tracker.finalize(), { costUsd: 0.03, source: "stream", estimated: false });
+		});
+
 		test("response cost tracker computes an estimated fallback from usage and route pricing", () => {
 			const tracker = new ResponseCostTracker({ inputCostPerToken: 0.001, outputCostPerToken: 0.002 });
 
 			tracker.addUsage({ prompt_tokens: 10, completion_tokens: 5 });
 
 			assert.deepEqual(tracker.finalize(), { costUsd: 0.02, source: "computed", estimated: true });
+		});
+
+		test("formats tiny cumulative session costs with the currency symbol before the threshold", () => {
+			assert.equal(formatSessionCostUsd(0.000099), "<$0.0001");
+			assert.equal(formatSessionCostUsd(0.0001), "$0.0001");
+			assert.equal(formatSessionCostUsd(0), undefined);
 		});
 	});
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,8 @@ export interface LiteLLMProvider {
 	supports_tools?: boolean;
 	supports_structured_output?: boolean;
 	context_length?: number;
+	input_cost_per_token?: number | null;
+	output_cost_per_token?: number | null;
 	// Model capability metadata (READ from /v1/models API endpoint)
 	// These define what the model CAN do, not what we ASK it to do.
 	// For customizing request parameters, use the modelParameters configuration.
@@ -133,6 +135,8 @@ export interface LiteLLMModelInfoItem {
 		max_tokens?: number | null;
 		max_input_tokens?: number | null;
 		max_output_tokens?: number | null;
+		input_cost_per_token?: number | null;
+		output_cost_per_token?: number | null;
 		litellm_provider?: string;
 		supports_function_calling?: boolean | null;
 		supports_tool_choice?: boolean | null;


### PR DESCRIPTION
Clean reimplementation of pricing metadata and live cost tracking.

This replaces #124 with a scoped implementation that preserves broad request parameter pass-through and avoids double-counting response costs.

Validation:
- bun run compile
- bun run lint
- bun run test