### PR TITLE
chore: update GitHub Actions for Node 24

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,7 +6,7 @@
 
 repository:
   description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.
-  homepage: https://github.com/Vivswan/litellm-vscode-chat
+  homepage: https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat
   topics: litellm, vscode-extension, copilot-chat, llm, ai, typescript, bun
   has_issues: true
   has_wiki: false

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title is a Conventional Commit
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           target-branch: main

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 		"color": "#100f11",
 		"theme": "dark"
 	},
-	"homepage": "https://github.com/Vivswan/litellm-vscode-chat",
+	"homepage": "https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat",
 	"icon": "assets/logo.png",
 	"license": "MIT",
 	"lint-staged": {


### PR DESCRIPTION
## Summary

Updates release and PR-title workflows to use Node 24-compatible action majors so CI avoids the GitHub Actions Node 20 deprecation path. Also points repository/package homepage metadata at the VS Code Marketplace listing.

## Checklist

- [ ] `bun run test` passes
- [ ] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Docs updated if needed
- [x] Follows the conventions in [AGENTS.md](../AGENTS.md)