### PR TITLE
feat: add OAuth2 client-credentials authentication for servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,26 @@ To manage servers:
 - **Model Picker**: Chat interface → Model picker → "Manage Models..." → "LiteLLM"
 
 From the server manager you can:
-- **Add Server** — provide a unique label, base URL, and optional API key
-- **Edit Server** — update label, URL, or API key
+- **Add Server** — provide a unique label, base URL, and choose an authentication method
+- **Edit Server** — update label, URL, or authentication method
 - **Remove Server** — delete a server and its stored credentials
 - **Test All Servers** — verify connectivity to every configured server
 
 If no servers are configured, the "Manage" command jumps straight to the add flow.
 
 Credentials are stored securely in VS Code's secret storage. Server metadata (label, URL) is stored in global state.
+
+#### Authentication methods
+
+When adding or editing a server you choose how it authenticates:
+
+- **API Key** — a static key sent as `Authorization: Bearer <key>` (and `X-API-Key`). Leave empty for a key-less proxy.
+- **OAuth (Client Credentials)** — for gateways that issue short-lived tokens from an identity provider. You provide:
+  - **Token URL (IDP)** — the OAuth token endpoint (e.g. `https://idp.example.com/auth/realms/<realm>/protocol/openid-connect/token`)
+  - **Client ID** / **Client Secret** — the `client_credentials` grant credentials
+  - **Virtual Key** (optional) — a client/virtual key sent in the `X-LLM-API-CLIENT-ID` header (the header name is configurable)
+
+  The extension exchanges the client credentials for an access token, caches it until shortly before it expires, and sends it as `Authorization: Bearer <token>` on both model discovery and chat requests. The client secret and virtual key are stored in VS Code's secret storage.
 
 **Upgrading from single-server**: Existing single-server configurations are automatically migrated into the server registry on first run.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,8 @@ We aim to acknowledge new reports on a best-effort basis, typically within a few
 
 `litellm-vscode-chat` is a VS Code extension that connects VS Code's Language Model Chat Provider API to user-configured LiteLLM servers.
 
-- **Secrets stay in VS Code storage.** LiteLLM API keys are stored in VS Code SecretStorage. Server labels and base URLs are stored in VS Code global state.
+- **Secrets stay in VS Code storage.** LiteLLM API keys are stored in VS Code SecretStorage. For servers using OAuth2 client-credentials auth, the client secret and virtual/client key are likewise stored in SecretStorage; the non-secret OAuth config (IDP token URL, client ID, virtual-key header name) and server labels and base URLs are stored in VS Code global state.
+- **OAuth access tokens are never persisted.** Tokens obtained via the client-credentials flow are held only in memory, cached until shortly before they expire, and discarded when the server's config changes or it is removed.
 - **User-controlled endpoints.** The extension sends prompts, tool definitions, and supported attachment data to the LiteLLM server configured by the user. Only configure servers you trust.
 - **No bundled model provider credentials.** The extension does not ship provider API keys; model-provider credentials are managed by the user's LiteLLM deployment.
 - **Supply-chain posture.** Dependencies are pinned via the committed `bun.lock` and installed with `bun install --frozen-lockfile` in CI and setup scripts.

--- a/src/extension/diagnostics.ts
+++ b/src/extension/diagnostics.ts
@@ -14,7 +14,8 @@ export async function buildDiagnosticsSnapshot(
 	const servers = registry.getServers();
 	const serversWithKeys = await registry.getServersWithKeys();
 	const hasApiKey =
-		serversWithKeys.some((s) => s.apiKey.trim().length > 0) || !!(await context.secrets.get("litellm.apiKey"));
+		serversWithKeys.some((s) => s.apiKey.trim().length > 0 || s.auth?.type === "oauth") ||
+		!!(await context.secrets.get("litellm.apiKey"));
 	const hasBaseUrl = servers.length > 0 || !!(await context.secrets.get("litellm.baseUrl"));
 
 	return {

--- a/src/extension/serverManagement.ts
+++ b/src/extension/serverManagement.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { ServerRegistry, OAuthInput, OAuthSecrets } from "./serverRegistry";
 import { DEFAULT_VIRTUAL_KEY_HEADER } from "../provider/auth";
+import { isValidHeaderName } from "../provider/httpHeaders";
 
 /**
  * Prompts for the OAuth client-credentials fields. `existing` pre-fills the
@@ -64,10 +65,17 @@ async function collectOAuthInput(existing?: OAuthSecrets): Promise<OAuthInput | 
 
 	const virtualKeyHeader = await vscode.window.showInputBox({
 		title: "LiteLLM: OAuth - Virtual Key Header",
-		prompt: "Header name for the virtual key",
+		prompt: `Header name for the virtual key (leave empty for the default ${DEFAULT_VIRTUAL_KEY_HEADER})`,
 		ignoreFocusOut: true,
 		value: existing?.virtualKeyHeader ?? DEFAULT_VIRTUAL_KEY_HEADER,
 		placeHolder: DEFAULT_VIRTUAL_KEY_HEADER,
+		validateInput: (value) => {
+			const trimmed = value.trim();
+			if (!trimmed) {
+				return null; // blank means use the default header name
+			}
+			return isValidHeaderName(trimmed) ? null : "Invalid header name (use letters, digits, and -._ only)";
+		},
 	});
 	if (virtualKeyHeader === undefined) {
 		return undefined;

--- a/src/extension/serverManagement.ts
+++ b/src/extension/serverManagement.ts
@@ -1,5 +1,110 @@
 import * as vscode from "vscode";
-import type { ServerRegistry } from "./serverRegistry";
+import type { ServerRegistry, OAuthInput, OAuthSecrets } from "./serverRegistry";
+import { DEFAULT_VIRTUAL_KEY_HEADER } from "../provider/auth";
+
+/**
+ * Prompts for the OAuth client-credentials fields. `existing` pre-fills the
+ * inputs when editing. Returns undefined if the user cancels any step.
+ */
+async function collectOAuthInput(existing?: OAuthSecrets): Promise<OAuthInput | undefined> {
+	const idpUrl = await vscode.window.showInputBox({
+		title: "LiteLLM: OAuth - Token URL (IDP)",
+		prompt: "Enter the OAuth token endpoint that issues the access token",
+		ignoreFocusOut: true,
+		value: existing?.idpUrl,
+		placeHolder: "https://idp.example.com/auth/realms/<realm>/protocol/openid-connect/token",
+		validateInput: (value) => {
+			if (!value.trim()) {
+				return "Token URL is required";
+			}
+			if (!value.startsWith("http://") && !value.startsWith("https://")) {
+				return "URL must start with http:// or https://";
+			}
+			return null;
+		},
+	});
+	if (idpUrl === undefined) {
+		return undefined;
+	}
+
+	const clientId = await vscode.window.showInputBox({
+		title: "LiteLLM: OAuth - Client ID",
+		prompt: "Enter the OAuth client_id",
+		ignoreFocusOut: true,
+		value: existing?.clientId,
+		validateInput: (value) => (value.trim() ? null : "Client ID is required"),
+	});
+	if (clientId === undefined) {
+		return undefined;
+	}
+
+	const maskSecret = vscode.workspace.getConfiguration("litellm-vscode-chat").get<boolean>("maskApiKeyInput", true);
+	const clientSecret = await vscode.window.showInputBox({
+		title: "LiteLLM: OAuth - Client Secret",
+		prompt: existing ? "Update the OAuth client_secret" : "Enter the OAuth client_secret",
+		ignoreFocusOut: true,
+		password: maskSecret,
+		value: existing?.clientSecret,
+		validateInput: (value) => (value.trim() ? null : "Client Secret is required"),
+	});
+	if (clientSecret === undefined) {
+		return undefined;
+	}
+
+	const virtualKey = await vscode.window.showInputBox({
+		title: "LiteLLM: OAuth - Virtual Key",
+		prompt: `Enter the virtual/client key sent in the ${DEFAULT_VIRTUAL_KEY_HEADER} header (leave empty if not required)`,
+		ignoreFocusOut: true,
+		password: maskSecret,
+		value: existing?.virtualKey,
+	});
+	if (virtualKey === undefined) {
+		return undefined;
+	}
+
+	const virtualKeyHeader = await vscode.window.showInputBox({
+		title: "LiteLLM: OAuth - Virtual Key Header",
+		prompt: "Header name for the virtual key",
+		ignoreFocusOut: true,
+		value: existing?.virtualKeyHeader ?? DEFAULT_VIRTUAL_KEY_HEADER,
+		placeHolder: DEFAULT_VIRTUAL_KEY_HEADER,
+	});
+	if (virtualKeyHeader === undefined) {
+		return undefined;
+	}
+
+	const trimmedHeader = virtualKeyHeader.trim();
+	return {
+		idpUrl: idpUrl.trim(),
+		clientId: clientId.trim(),
+		clientSecret: clientSecret.trim(),
+		virtualKey: virtualKey.trim(),
+		...(trimmedHeader && trimmedHeader !== DEFAULT_VIRTUAL_KEY_HEADER ? { virtualKeyHeader: trimmedHeader } : {}),
+	};
+}
+
+/** Asks the user which auth method to use. Returns undefined on cancel. */
+async function pickAuthType(current?: "apikey" | "oauth"): Promise<"apikey" | "oauth" | undefined> {
+	const items: (vscode.QuickPickItem & { value: "apikey" | "oauth" })[] = [
+		{
+			label: "$(key) API Key",
+			description: current === "apikey" ? "(current)" : undefined,
+			detail: "Static API key sent as a Bearer token",
+			value: "apikey",
+		},
+		{
+			label: "$(shield) OAuth (Client Credentials)",
+			description: current === "oauth" ? "(current)" : undefined,
+			detail: "Fetch a bearer token from an IDP using client_id / client_secret",
+			value: "oauth",
+		},
+	];
+	const pick = await vscode.window.showQuickPick(items, {
+		title: "LiteLLM: Authentication Method",
+		placeHolder: "How does this server authenticate?",
+	});
+	return pick?.value;
+}
 
 export async function addServerFlow(registry: ServerRegistry, outputChannel: vscode.OutputChannel): Promise<boolean> {
 	const label = await vscode.window.showInputBox({
@@ -43,18 +148,30 @@ export async function addServerFlow(registry: ServerRegistry, outputChannel: vsc
 		return false;
 	}
 
-	const maskApiKey = vscode.workspace.getConfiguration("litellm-vscode-chat").get<boolean>("maskApiKeyInput", true);
-	const apiKey = await vscode.window.showInputBox({
-		title: "LiteLLM: Add Server - API Key",
-		prompt: "Enter the API key (leave empty if not required)",
-		ignoreFocusOut: true,
-		password: maskApiKey,
-	});
-	if (apiKey === undefined) {
+	const authType = await pickAuthType();
+	if (authType === undefined) {
 		return false;
 	}
 
-	await registry.addServer(label.trim(), baseUrl.trim(), apiKey.trim());
+	if (authType === "oauth") {
+		const oauth = await collectOAuthInput();
+		if (oauth === undefined) {
+			return false;
+		}
+		await registry.addOAuthServer(label.trim(), baseUrl.trim(), oauth);
+	} else {
+		const maskApiKey = vscode.workspace.getConfiguration("litellm-vscode-chat").get<boolean>("maskApiKeyInput", true);
+		const apiKey = await vscode.window.showInputBox({
+			title: "LiteLLM: Add Server - API Key",
+			prompt: "Enter the API key (leave empty if not required)",
+			ignoreFocusOut: true,
+			password: maskApiKey,
+		});
+		if (apiKey === undefined) {
+			return false;
+		}
+		await registry.addServer(label.trim(), baseUrl.trim(), apiKey.trim());
+	}
 	outputChannel.appendLine(`[${new Date().toISOString()}] Added server "${label.trim()}" at ${baseUrl.trim()}`);
 
 	vscode.window
@@ -139,20 +256,34 @@ export async function manageServerFlow(
 			return;
 		}
 
-		const existingApiKey = await registry.getApiKey(serverId);
-		const maskApiKey = vscode.workspace.getConfiguration("litellm-vscode-chat").get<boolean>("maskApiKeyInput", true);
-		const apiKey = await vscode.window.showInputBox({
-			title: "LiteLLM: Edit Server - API Key",
-			prompt: existingApiKey ? "Update the API key" : "Enter the API key (leave empty if not required)",
-			ignoreFocusOut: true,
-			password: maskApiKey,
-			value: existingApiKey,
-		});
-		if (apiKey === undefined) {
+		const currentAuthType = server.auth?.type === "oauth" ? "oauth" : "apikey";
+		const authType = await pickAuthType(currentAuthType);
+		if (authType === undefined) {
 			return;
 		}
 
-		await registry.updateServer(serverId, label.trim(), baseUrl.trim(), apiKey.trim());
+		if (authType === "oauth") {
+			const existingOAuth = await registry.getOAuthSecrets(server);
+			const oauth = await collectOAuthInput(existingOAuth);
+			if (oauth === undefined) {
+				return;
+			}
+			await registry.updateOAuthServer(serverId, label.trim(), baseUrl.trim(), oauth);
+		} else {
+			const existingApiKey = await registry.getApiKey(serverId);
+			const maskApiKey = vscode.workspace.getConfiguration("litellm-vscode-chat").get<boolean>("maskApiKeyInput", true);
+			const apiKey = await vscode.window.showInputBox({
+				title: "LiteLLM: Edit Server - API Key",
+				prompt: existingApiKey ? "Update the API key" : "Enter the API key (leave empty if not required)",
+				ignoreFocusOut: true,
+				password: maskApiKey,
+				value: existingApiKey,
+			});
+			if (apiKey === undefined) {
+				return;
+			}
+			await registry.updateServer(serverId, label.trim(), baseUrl.trim(), apiKey.trim());
+		}
 		outputChannel.appendLine(`[${new Date().toISOString()}] Updated server "${label.trim()}"`);
 
 		vscode.window

--- a/src/extension/serverRegistry.ts
+++ b/src/extension/serverRegistry.ts
@@ -1,13 +1,46 @@
 import * as vscode from "vscode";
+import { clearTokenCache } from "../provider/auth";
+
+/** Non-secret OAuth client-credentials config persisted alongside a server. */
+export interface OAuthConfig {
+	type: "oauth";
+	/** IDP token endpoint that issues the access token. */
+	idpUrl: string;
+	clientId: string;
+	/** Header the proxy expects the virtual key in (defaults applied at request time). */
+	virtualKeyHeader?: string;
+}
+
+/** OAuth config with the secrets resolved from SecretStorage, ready to use. */
+export interface OAuthSecrets {
+	idpUrl: string;
+	clientId: string;
+	clientSecret: string;
+	virtualKey: string;
+	virtualKeyHeader?: string;
+}
+
+/** Parameters for creating/updating an OAuth client-credentials server. */
+export interface OAuthInput {
+	idpUrl: string;
+	clientId: string;
+	clientSecret: string;
+	virtualKey: string;
+	virtualKeyHeader?: string;
+}
 
 export interface ServerConfig {
 	id: string;
 	label: string;
 	baseUrl: string;
+	/** Present only for OAuth servers; absent means static API key auth. */
+	auth?: OAuthConfig;
 }
 
 export interface ServerWithKey extends ServerConfig {
 	apiKey: string;
+	/** Present only for OAuth servers; carries the resolved secrets. */
+	oauth?: OAuthSecrets;
 }
 
 export interface ServerStatus {
@@ -24,6 +57,14 @@ const REGISTRY_KEY = "litellm.serverRegistry";
 
 function apiKeySecret(serverId: string): string {
 	return `litellm.apiKey.${serverId}`;
+}
+
+function clientSecretSecret(serverId: string): string {
+	return `litellm.oauth.clientSecret.${serverId}`;
+}
+
+function virtualKeySecret(serverId: string): string {
+	return `litellm.oauth.virtualKey.${serverId}`;
 }
 
 export class ServerRegistry {
@@ -60,6 +101,10 @@ export class ServerRegistry {
 		}
 		servers[idx] = { id, label, baseUrl: baseUrl.replace(/\/+$/, "") };
 		await this.globalState.update(REGISTRY_KEY, servers);
+		// Switching to API-key auth: drop any stale OAuth secrets/token.
+		await this.secrets.delete(clientSecretSecret(id));
+		await this.secrets.delete(virtualKeySecret(id));
+		clearTokenCache(id);
 		if (apiKey !== undefined) {
 			if (apiKey) {
 				await this.secrets.store(apiKeySecret(id), apiKey);
@@ -69,14 +114,72 @@ export class ServerRegistry {
 		}
 	}
 
+	async addOAuthServer(label: string, baseUrl: string, oauth: OAuthInput): Promise<ServerConfig> {
+		const existingIds = new Set(this.getServers().map((s) => s.id));
+		let id = generateId();
+		while (existingIds.has(id)) {
+			id = generateId();
+		}
+		const auth: OAuthConfig = {
+			type: "oauth",
+			idpUrl: oauth.idpUrl,
+			clientId: oauth.clientId,
+			...(oauth.virtualKeyHeader ? { virtualKeyHeader: oauth.virtualKeyHeader } : {}),
+		};
+		const server: ServerConfig = { id, label, baseUrl: baseUrl.replace(/\/+$/, ""), auth };
+		const servers = this.getServers();
+		servers.push(server);
+		await this.globalState.update(REGISTRY_KEY, servers);
+		await this.secrets.store(clientSecretSecret(id), oauth.clientSecret);
+		await this.secrets.store(virtualKeySecret(id), oauth.virtualKey);
+		return server;
+	}
+
+	async updateOAuthServer(id: string, label: string, baseUrl: string, oauth: OAuthInput): Promise<void> {
+		const servers = this.getServers();
+		const idx = servers.findIndex((s) => s.id === id);
+		if (idx === -1) {
+			return;
+		}
+		const auth: OAuthConfig = {
+			type: "oauth",
+			idpUrl: oauth.idpUrl,
+			clientId: oauth.clientId,
+			...(oauth.virtualKeyHeader ? { virtualKeyHeader: oauth.virtualKeyHeader } : {}),
+		};
+		servers[idx] = { id, label, baseUrl: baseUrl.replace(/\/+$/, ""), auth };
+		await this.globalState.update(REGISTRY_KEY, servers);
+		// Switching to OAuth auth: drop any stale static API key.
+		await this.secrets.delete(apiKeySecret(id));
+		await this.secrets.store(clientSecretSecret(id), oauth.clientSecret);
+		await this.secrets.store(virtualKeySecret(id), oauth.virtualKey);
+		clearTokenCache(id);
+	}
+
 	async removeServer(id: string): Promise<void> {
 		const servers = this.getServers().filter((s) => s.id !== id);
 		await this.globalState.update(REGISTRY_KEY, servers);
 		await this.secrets.delete(apiKeySecret(id));
+		await this.secrets.delete(clientSecretSecret(id));
+		await this.secrets.delete(virtualKeySecret(id));
+		clearTokenCache(id);
 	}
 
 	async getApiKey(serverId: string): Promise<string> {
 		return (await this.secrets.get(apiKeySecret(serverId))) ?? "";
+	}
+
+	async getOAuthSecrets(server: ServerConfig): Promise<OAuthSecrets | undefined> {
+		if (server.auth?.type !== "oauth") {
+			return undefined;
+		}
+		return {
+			idpUrl: server.auth.idpUrl,
+			clientId: server.auth.clientId,
+			clientSecret: (await this.secrets.get(clientSecretSecret(server.id))) ?? "",
+			virtualKey: (await this.secrets.get(virtualKeySecret(server.id))) ?? "",
+			...(server.auth.virtualKeyHeader ? { virtualKeyHeader: server.auth.virtualKeyHeader } : {}),
+		};
 	}
 
 	async getServersWithKeys(): Promise<ServerWithKey[]> {
@@ -84,7 +187,8 @@ export class ServerRegistry {
 		return Promise.all(
 			servers.map(async (s) => ({
 				...s,
-				apiKey: await this.getApiKey(s.id),
+				apiKey: s.auth?.type === "oauth" ? "" : await this.getApiKey(s.id),
+				oauth: await this.getOAuthSecrets(s),
 			}))
 		);
 	}

--- a/src/issueReporter.ts
+++ b/src/issueReporter.ts
@@ -351,10 +351,14 @@ export function redactSecrets(text: string): string {
 		text
 			// JSON-encoded auth headers: "Authorization": "Bearer xxx" or "X-API-Key": "xxx"
 			.replace(/("(?:Authorization|X-API-Key)":\s*")((?:Bearer\s+)?)[^"]*(")/gi, "$1$2[REDACTED]$3")
+			// JSON-encoded OAuth virtual/client-key headers (default X-LLM-API-CLIENT-ID and custom variants)
+			.replace(/("[A-Za-z0-9-]*(?:client-id|virtual-key)":\s*")[^"]*(")/gi, "$1[REDACTED]$2")
 			// Bare auth header values
 			.replace(/(Bearer\s+)\S+/gi, "$1[REDACTED]")
 			.replace(/(X-API-Key:\s*)\S+/gi, "$1[REDACTED]")
 			.replace(/(Authorization:\s*)\S+/gi, "$1[REDACTED]")
+			// Bare OAuth virtual/client-key header values
+			.replace(/([A-Za-z0-9-]*(?:client-id|virtual-key):\s*)\S+/gi, "$1[REDACTED]")
 			.replace(/(api[_-]?key[=:\s]+)\S+/gi, "$1[REDACTED]")
 			// sk- prefixed API keys
 			.replace(/(sk-[a-zA-Z0-9]{4})[a-zA-Z0-9]+/g, "$1[REDACTED]")

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -125,7 +125,8 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 					(msg, data) => this.log(msg, data),
 					(msg, err) => this.logError(msg, err),
 					customHeaders,
-					discoveryTimeout
+					discoveryTimeout,
+					server.auth?.type === "oauth" ? "oauth" : "apikey"
 				);
 				return { server, models: result.models };
 			})

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -16,6 +16,7 @@ import type { ModelRoute } from "./provider/request";
 import { fetchModels } from "./provider/discovery";
 import { buildModelInfos } from "./provider/registration";
 import { ensureServers } from "./provider/config";
+import { resolveAuthHeaders } from "./provider/auth";
 import { sendChatRequest } from "./provider/client";
 import { getCustomHeaders } from "./provider/httpHeaders";
 
@@ -116,8 +117,9 @@ export class LiteLLMChatModelProvider implements LanguageModelChatProvider {
 
 		const results = await Promise.allSettled(
 			servers.map(async (server) => {
+				const authHeaders = await resolveAuthHeaders(server, (msg, data) => this.log(msg, data), discoveryTimeout);
 				const result = await fetchModels(
-					server.apiKey,
+					authHeaders,
 					server.baseUrl,
 					this.userAgent,
 					(msg, data) => this.log(msg, data),

--- a/src/provider/auth.ts
+++ b/src/provider/auth.ts
@@ -1,0 +1,104 @@
+import type { OAuthSecrets } from "../extension/serverRegistry";
+
+/** Default header the LiteLLM proxy expects the virtual/client key in. */
+export const DEFAULT_VIRTUAL_KEY_HEADER = "X-LLM-API-CLIENT-ID";
+
+interface CachedToken {
+	token: string;
+	expiresAt: number;
+}
+
+// Token cache keyed by server id. OAuth access tokens are short-lived, so we
+// reuse a cached token until shortly before it expires instead of hitting the
+// IDP on every request/discovery.
+const tokenCache = new Map<string, CachedToken>();
+
+/** Drop any cached token for a server (call when its OAuth config changes or it is removed). */
+export function clearTokenCache(serverId?: string): void {
+	if (serverId === undefined) {
+		tokenCache.clear();
+	} else {
+		tokenCache.delete(serverId);
+	}
+}
+
+async function getOAuthToken(
+	serverId: string,
+	oauth: OAuthSecrets,
+	timeout: number,
+	log?: (message: string, data?: unknown) => void
+): Promise<string> {
+	const now = Date.now();
+	const cached = tokenCache.get(serverId);
+	if (cached && cached.expiresAt > now) {
+		return cached.token;
+	}
+
+	log?.("Requesting OAuth token", { idpUrl: oauth.idpUrl, clientId: oauth.clientId });
+	const response = await fetch(oauth.idpUrl, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "client_credentials",
+			client_id: oauth.clientId,
+			client_secret: oauth.clientSecret,
+		}).toString(),
+		signal: AbortSignal.timeout(timeout),
+	});
+
+	if (!response.ok) {
+		let text = "";
+		try {
+			text = await response.text();
+		} catch {
+			// ignore body read failures
+		}
+		throw new Error(`OAuth token request failed: ${response.status} ${response.statusText}${text ? `\n${text}` : ""}`);
+	}
+
+	const data = (await response.json()) as { access_token?: string; expires_in?: number };
+	if (!data.access_token) {
+		throw new Error("OAuth token response did not include an access_token");
+	}
+
+	// Refresh a minute early so an in-flight request never carries a just-expired token.
+	const expiresIn = typeof data.expires_in === "number" && data.expires_in > 0 ? data.expires_in : 300;
+	tokenCache.set(serverId, { token: data.access_token, expiresAt: now + (expiresIn - 60) * 1000 });
+	return data.access_token;
+}
+
+export interface AuthResolvable {
+	id: string;
+	apiKey: string;
+	auth?: { type: "oauth" };
+	oauth?: OAuthSecrets;
+}
+
+/**
+ * Resolves the authentication headers for a server. For OAuth servers this
+ * fetches (and caches) a bearer token via the client-credentials flow and adds
+ * the virtual-key header; for API-key servers it returns the static
+ * Authorization / X-API-Key headers. Returns an empty object when nothing is
+ * configured (e.g. a key-less local proxy).
+ */
+export async function resolveAuthHeaders(
+	server: AuthResolvable,
+	log?: (message: string, data?: unknown) => void,
+	timeout = 30000
+): Promise<Record<string, string>> {
+	if (server.auth?.type === "oauth" && server.oauth) {
+		const token = await getOAuthToken(server.id, server.oauth, timeout, log);
+		const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+		if (server.oauth.virtualKey) {
+			const headerName = server.oauth.virtualKeyHeader || DEFAULT_VIRTUAL_KEY_HEADER;
+			headers[headerName] = `Bearer ${server.oauth.virtualKey}`;
+		}
+		return headers;
+	}
+
+	if (server.apiKey) {
+		return { Authorization: `Bearer ${server.apiKey}`, "X-API-Key": server.apiKey };
+	}
+
+	return {};
+}

--- a/src/provider/auth.ts
+++ b/src/provider/auth.ts
@@ -3,6 +3,17 @@ import type { OAuthSecrets } from "../extension/serverRegistry";
 /** Default header the LiteLLM proxy expects the virtual/client key in. */
 export const DEFAULT_VIRTUAL_KEY_HEADER = "X-LLM-API-CLIENT-ID";
 
+/**
+ * Builds the user-facing message for a 401 from the LiteLLM server, tailored to
+ * how the server authenticates so OAuth users aren't told to "configure an API key".
+ */
+export function authFailureMessage(authMethod: "oauth" | "apikey"): string {
+	if (authMethod === "oauth") {
+		return `Authentication failed: the LiteLLM server rejected the OAuth access token. Run the "Manage LiteLLM Provider" command to verify the token URL, client ID/secret, and virtual key.`;
+	}
+	return `Authentication failed: your LiteLLM server requires a valid API key. Please run the "Manage LiteLLM Provider" command to configure your API key.`;
+}
+
 interface CachedToken {
 	token: string;
 	expiresAt: number;

--- a/src/provider/auth.ts
+++ b/src/provider/auth.ts
@@ -61,9 +61,12 @@ async function getOAuthToken(
 		throw new Error("OAuth token response did not include an access_token");
 	}
 
-	// Refresh a minute early so an in-flight request never carries a just-expired token.
+	// Refresh early so an in-flight request never carries a just-expired token, but
+	// clamp the skew so short-lived tokens (expires_in <= 60) stay cached for a usable
+	// window instead of being treated as already expired and re-fetched every call.
 	const expiresIn = typeof data.expires_in === "number" && data.expires_in > 0 ? data.expires_in : 300;
-	tokenCache.set(serverId, { token: data.access_token, expiresAt: now + (expiresIn - 60) * 1000 });
+	const refreshSkew = Math.min(60, Math.floor(expiresIn / 2));
+	tokenCache.set(serverId, { token: data.access_token, expiresAt: now + (expiresIn - refreshSkew) * 1000 });
 	return data.access_token;
 }
 
@@ -90,8 +93,11 @@ export async function resolveAuthHeaders(
 		const token = await getOAuthToken(server.id, server.oauth, timeout, log);
 		const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
 		if (server.oauth.virtualKey) {
+			// The virtual/client key is an opaque identifier: send it verbatim so servers
+			// that expect the value as-is work. If a gateway needs a prefix (e.g. "Bearer "),
+			// the user includes it in the virtual key value itself.
 			const headerName = server.oauth.virtualKeyHeader || DEFAULT_VIRTUAL_KEY_HEADER;
-			headers[headerName] = `Bearer ${server.oauth.virtualKey}`;
+			headers[headerName] = server.oauth.virtualKey;
 		}
 		return headers;
 	}

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -11,7 +11,7 @@ import { estimateMessagesTokens, estimateToolTokens, getModelParameters, buildRe
 import type { ModelRoute } from "./request";
 import { StreamProcessor } from "./streaming";
 import { resolveServer } from "./config";
-import { resolveAuthHeaders } from "./auth";
+import { resolveAuthHeaders, authFailureMessage } from "./auth";
 import { getCustomHeaders } from "./httpHeaders";
 import type { ServerWithKey } from "../extension/serverRegistry";
 
@@ -39,6 +39,7 @@ export async function sendChatRequest(
 	const route = modelRoutes.get(model.id);
 	let baseUrl: string;
 	let authHeaders: Record<string, string>;
+	let authMethod: "oauth" | "apikey" = "apikey";
 	let rawModelId: string;
 
 	if (route) {
@@ -46,6 +47,7 @@ export async function sendChatRequest(
 		if (server) {
 			baseUrl = server.baseUrl;
 			authHeaders = await resolveAuthHeaders(server, log);
+			authMethod = server.auth?.type === "oauth" ? "oauth" : "apikey";
 		} else {
 			throw new Error(`Server "${route.serverLabel}" is no longer configured`);
 		}
@@ -137,9 +139,7 @@ export async function sendChatRequest(
 		logError("API error response", errorText);
 
 		if (response.status === 401) {
-			throw new Error(
-				`Authentication failed: Your LiteLLM server requires an API key. Please run the "Manage LiteLLM Provider" command to configure your API key.`
-			);
+			throw new Error(authFailureMessage(authMethod));
 		}
 
 		throw new Error(`LiteLLM API error: ${response.status} ${response.statusText}${errorText ? `\n${errorText}` : ""}`);

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -11,6 +11,7 @@ import { estimateMessagesTokens, estimateToolTokens, getModelParameters, buildRe
 import type { ModelRoute } from "./request";
 import { StreamProcessor } from "./streaming";
 import { resolveServer } from "./config";
+import { resolveAuthHeaders } from "./auth";
 import { getCustomHeaders } from "./httpHeaders";
 import type { ServerWithKey } from "../extension/serverRegistry";
 
@@ -37,14 +38,14 @@ export async function sendChatRequest(
 
 	const route = modelRoutes.get(model.id);
 	let baseUrl: string;
-	let apiKey: string;
+	let authHeaders: Record<string, string>;
 	let rawModelId: string;
 
 	if (route) {
 		const server = await resolveServer(route.serverId, getServers, secrets);
 		if (server) {
 			baseUrl = server.baseUrl;
-			apiKey = server.apiKey;
+			authHeaders = await resolveAuthHeaders(server, log);
 		} else {
 			throw new Error(`Server "${route.serverLabel}" is no longer configured`);
 		}
@@ -55,7 +56,7 @@ export async function sendChatRequest(
 			throw new Error("LiteLLM configuration not found");
 		}
 		baseUrl = config.baseUrl;
-		apiKey = config.apiKey;
+		authHeaders = await resolveAuthHeaders(config, log);
 		rawModelId = model.id;
 	}
 
@@ -110,15 +111,13 @@ export async function sendChatRequest(
 		modelOptions: options.modelOptions as Record<string, unknown> | undefined,
 	});
 
+	// Auth headers take precedence over custom headers; Content-Type and User-Agent are always forced.
 	const headers: Record<string, string> = {
 		...customHeaders,
+		...authHeaders,
 		"Content-Type": "application/json",
 		"User-Agent": userAgent,
 	};
-	if (apiKey) {
-		headers.Authorization = `Bearer ${apiKey}`;
-		headers["X-API-Key"] = apiKey;
-	}
 
 	log("Sending chat request", {
 		url: `${baseUrl}/v1/chat/completions`,

--- a/src/provider/config.ts
+++ b/src/provider/config.ts
@@ -1,13 +1,16 @@
 import * as vscode from "vscode";
 import type { ServerWithKey } from "../extension/serverRegistry";
 
+export type ResolvedServer = Pick<ServerWithKey, "id" | "baseUrl" | "apiKey" | "auth" | "oauth">;
+
 export async function resolveServer(
 	serverId: string,
 	getServers: (() => Promise<ServerWithKey[]>) | undefined,
 	secrets: vscode.SecretStorage
-): Promise<{ baseUrl: string; apiKey: string } | undefined> {
+): Promise<ResolvedServer | undefined> {
 	if (serverId === "_legacy") {
-		return ensureConfig(secrets);
+		const config = await ensureConfig(secrets);
+		return config ? { id: "_legacy", baseUrl: config.baseUrl, apiKey: config.apiKey } : undefined;
 	}
 	if (!getServers) {
 		return undefined;

--- a/src/provider/discovery.ts
+++ b/src/provider/discovery.ts
@@ -6,6 +6,7 @@ import type {
 	LiteLLMProvider,
 } from "../types";
 import { normalizePositiveNumber } from "../shared/numbers";
+import { authFailureMessage } from "./auth";
 
 export function mapModelInfoToLiteLLMModel(item: LiteLLMModelInfoItem): LiteLLMModelItem | undefined {
 	const modelId = item.model_name ?? item.litellm_params?.model ?? item.model_info?.key ?? item.model_info?.id;
@@ -68,7 +69,8 @@ export async function fetchModels(
 	log: (message: string, data?: unknown) => void,
 	logError: (message: string, error: unknown) => void,
 	customHeaders: Record<string, string> = {},
-	discoveryTimeout?: number
+	discoveryTimeout?: number,
+	authMethod: "oauth" | "apikey" = "apikey"
 ): Promise<FetchModelsResult> {
 	// Validate and clamp timeout to minimum 1000ms (second line of defense)
 	const rawTimeout = discoveryTimeout ?? 30000;
@@ -96,9 +98,7 @@ export async function fetchModels(
 	const handleNonOk = async (resp: Response): Promise<never> => {
 		const text = await readErrorText(resp);
 		if (resp.status === 401) {
-			const err = new Error(
-				`Authentication failed: Your LiteLLM server requires an API key. Please run the "Manage LiteLLM Provider" command to configure your API key.`
-			);
+			const err = new Error(authFailureMessage(authMethod));
 			logError("Authentication error", err);
 			throw err;
 		}

--- a/src/provider/discovery.ts
+++ b/src/provider/discovery.ts
@@ -62,7 +62,7 @@ export interface FetchModelsResult {
 }
 
 export async function fetchModels(
-	apiKey: string,
+	authHeaders: Record<string, string>,
 	baseUrl: string,
 	userAgent: string,
 	log: (message: string, data?: unknown) => void,
@@ -79,12 +79,9 @@ export async function fetchModels(
 			clamped: timeout,
 		});
 	}
-	log("fetchModels called", { baseUrl, hasApiKey: !!apiKey });
-	const headers: Record<string, string> = { ...customHeaders, "User-Agent": userAgent };
-	if (apiKey) {
-		headers.Authorization = `Bearer ${apiKey}`;
-		headers["X-API-Key"] = apiKey;
-	}
+	log("fetchModels called", { baseUrl, hasAuth: Object.keys(authHeaders).length > 0 });
+	// Auth headers take precedence over custom headers; User-Agent is always forced.
+	const headers: Record<string, string> = { ...customHeaders, ...authHeaders, "User-Agent": userAgent };
 
 	const readErrorText = async (resp: Response): Promise<string> => {
 		let text = "";

--- a/src/provider/httpHeaders.ts
+++ b/src/provider/httpHeaders.ts
@@ -2,6 +2,11 @@ import * as vscode from "vscode";
 
 const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 
+/** True if `name` is a valid RFC 7230 header field name (token characters only). */
+export function isValidHeaderName(name: string): boolean {
+	return HEADER_NAME_PATTERN.test(name);
+}
+
 function normalizeCustomHeaders(raw: unknown, log?: (message: string, data?: unknown) => void): Record<string, string> {
 	if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
 		return {};

--- a/src/test/issueReporter.test.ts
+++ b/src/test/issueReporter.test.ts
@@ -330,4 +330,21 @@ suite("IssueReporter", () => {
 		assert.ok(!result.includes("secret-key-value"), "Should not leak API key");
 		assert.ok(result.includes("[REDACTED]"));
 	});
+
+	test("redactSecrets removes the default OAuth virtual-key header value", () => {
+		assert.equal(redactSecrets("X-LLM-API-CLIENT-ID: vk-secret123"), "X-LLM-API-CLIENT-ID: [REDACTED]");
+	});
+
+	test("redactSecrets removes custom virtual-key header values", () => {
+		const result = redactSecrets("X-Custom-Virtual-Key: abc999");
+		assert.ok(!result.includes("abc999"), "Should not leak the virtual key");
+		assert.ok(result.includes("[REDACTED]"));
+	});
+
+	test("redactSecrets handles JSON-encoded virtual-key headers", () => {
+		const json = '{"X-LLM-API-CLIENT-ID": "vk-secret123"}';
+		const result = redactSecrets(json);
+		assert.ok(!result.includes("vk-secret123"), "Should not leak the virtual key");
+		assert.ok(result.includes("[REDACTED]"));
+	});
 });

--- a/src/test/provider/auth.test.ts
+++ b/src/test/provider/auth.test.ts
@@ -44,7 +44,7 @@ suite("provider/auth", () => {
 			});
 
 			assert.equal(headers.Authorization, "Bearer tok-123");
-			assert.equal(headers[DEFAULT_VIRTUAL_KEY_HEADER], "Bearer vkey");
+			assert.equal(headers[DEFAULT_VIRTUAL_KEY_HEADER], "vkey");
 			assert.equal(capturedUrl, "https://idp.example.com/token");
 			assert.ok(capturedBody.includes("grant_type=client_credentials"));
 			assert.ok(capturedBody.includes("client_id=cid"));
@@ -80,6 +80,32 @@ suite("provider/auth", () => {
 		}
 	});
 
+	test("short-lived tokens (expires_in <= 60) are still cached, not re-fetched every call", async () => {
+		const originalFetch = global.fetch;
+		let calls = 0;
+		try {
+			global.fetch = async () => {
+				calls++;
+				return {
+					ok: true,
+					json: async () => ({ access_token: "tok-short", expires_in: 30 }),
+				} as unknown as Response;
+			};
+
+			const server = {
+				id: "oauth-short",
+				apiKey: "",
+				auth: { type: "oauth" as const },
+				oauth: { idpUrl: "https://idp.example.com/token", clientId: "c", clientSecret: "s", virtualKey: "v" },
+			};
+			await resolveAuthHeaders(server);
+			await resolveAuthHeaders(server);
+			assert.equal(calls, 1, "a 30s token should remain cached for a usable window");
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+
 	test("custom virtual-key header name is honored", async () => {
 		const originalFetch = global.fetch;
 		try {
@@ -99,7 +125,7 @@ suite("provider/auth", () => {
 				},
 			});
 
-			assert.equal(headers["X-Custom-Client"], "Bearer v");
+			assert.equal(headers["X-Custom-Client"], "v");
 			assert.equal(headers[DEFAULT_VIRTUAL_KEY_HEADER], undefined);
 		} finally {
 			global.fetch = originalFetch;

--- a/src/test/provider/auth.test.ts
+++ b/src/test/provider/auth.test.ts
@@ -1,0 +1,148 @@
+import * as assert from "assert";
+import { resolveAuthHeaders, clearTokenCache, DEFAULT_VIRTUAL_KEY_HEADER } from "../../provider/auth";
+
+suite("provider/auth", () => {
+	teardown(() => {
+		clearTokenCache();
+	});
+
+	test("API-key server sends Bearer + X-API-Key headers", async () => {
+		const headers = await resolveAuthHeaders({ id: "s1", apiKey: "secret-key" });
+		assert.equal(headers.Authorization, "Bearer secret-key");
+		assert.equal(headers["X-API-Key"], "secret-key");
+	});
+
+	test("key-less server sends no auth headers", async () => {
+		const headers = await resolveAuthHeaders({ id: "s1", apiKey: "" });
+		assert.deepEqual(headers, {});
+	});
+
+	test("OAuth server fetches a token and adds the virtual-key header", async () => {
+		const originalFetch = global.fetch;
+		let capturedBody = "";
+		let capturedUrl = "";
+		try {
+			global.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+				capturedUrl = url.toString();
+				capturedBody = init?.body as string;
+				return {
+					ok: true,
+					json: async () => ({ access_token: "tok-123", expires_in: 3600 }),
+				} as unknown as Response;
+			};
+
+			const headers = await resolveAuthHeaders({
+				id: "oauth-1",
+				apiKey: "",
+				auth: { type: "oauth" },
+				oauth: {
+					idpUrl: "https://idp.example.com/token",
+					clientId: "cid",
+					clientSecret: "csecret",
+					virtualKey: "vkey",
+				},
+			});
+
+			assert.equal(headers.Authorization, "Bearer tok-123");
+			assert.equal(headers[DEFAULT_VIRTUAL_KEY_HEADER], "Bearer vkey");
+			assert.equal(capturedUrl, "https://idp.example.com/token");
+			assert.ok(capturedBody.includes("grant_type=client_credentials"));
+			assert.ok(capturedBody.includes("client_id=cid"));
+			assert.ok(capturedBody.includes("client_secret=csecret"));
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+
+	test("OAuth token is cached across calls", async () => {
+		const originalFetch = global.fetch;
+		let calls = 0;
+		try {
+			global.fetch = async () => {
+				calls++;
+				return {
+					ok: true,
+					json: async () => ({ access_token: "tok-cache", expires_in: 3600 }),
+				} as unknown as Response;
+			};
+
+			const server = {
+				id: "oauth-cache",
+				apiKey: "",
+				auth: { type: "oauth" as const },
+				oauth: { idpUrl: "https://idp.example.com/token", clientId: "c", clientSecret: "s", virtualKey: "v" },
+			};
+			await resolveAuthHeaders(server);
+			await resolveAuthHeaders(server);
+			assert.equal(calls, 1, "token should be fetched only once and then cached");
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+
+	test("custom virtual-key header name is honored", async () => {
+		const originalFetch = global.fetch;
+		try {
+			global.fetch = async () =>
+				({ ok: true, json: async () => ({ access_token: "t", expires_in: 3600 }) }) as unknown as Response;
+
+			const headers = await resolveAuthHeaders({
+				id: "oauth-hdr",
+				apiKey: "",
+				auth: { type: "oauth" },
+				oauth: {
+					idpUrl: "https://idp.example.com/token",
+					clientId: "c",
+					clientSecret: "s",
+					virtualKey: "v",
+					virtualKeyHeader: "X-Custom-Client",
+				},
+			});
+
+			assert.equal(headers["X-Custom-Client"], "Bearer v");
+			assert.equal(headers[DEFAULT_VIRTUAL_KEY_HEADER], undefined);
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+
+	test("OAuth without a virtual key only sends the bearer token", async () => {
+		const originalFetch = global.fetch;
+		try {
+			global.fetch = async () =>
+				({ ok: true, json: async () => ({ access_token: "t-only", expires_in: 3600 }) }) as unknown as Response;
+
+			const headers = await resolveAuthHeaders({
+				id: "oauth-novk",
+				apiKey: "",
+				auth: { type: "oauth" },
+				oauth: { idpUrl: "https://idp.example.com/token", clientId: "c", clientSecret: "s", virtualKey: "" },
+			});
+
+			assert.equal(headers.Authorization, "Bearer t-only");
+			assert.equal(headers[DEFAULT_VIRTUAL_KEY_HEADER], undefined);
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+
+	test("a failed token request throws", async () => {
+		const originalFetch = global.fetch;
+		try {
+			global.fetch = async () =>
+				({ ok: false, status: 401, statusText: "Unauthorized", text: async () => "bad creds" }) as unknown as Response;
+
+			await assert.rejects(
+				resolveAuthHeaders({
+					id: "oauth-fail",
+					apiKey: "",
+					auth: { type: "oauth" },
+					oauth: { idpUrl: "https://idp.example.com/token", clientId: "c", clientSecret: "s", virtualKey: "v" },
+				}),
+				/OAuth token request failed: 401/
+			);
+		} finally {
+			global.fetch = originalFetch;
+		}
+	});
+});

--- a/src/test/provider/auth.test.ts
+++ b/src/test/provider/auth.test.ts
@@ -1,5 +1,10 @@
 import * as assert from "assert";
-import { resolveAuthHeaders, clearTokenCache, DEFAULT_VIRTUAL_KEY_HEADER } from "../../provider/auth";
+import {
+	resolveAuthHeaders,
+	clearTokenCache,
+	authFailureMessage,
+	DEFAULT_VIRTUAL_KEY_HEADER,
+} from "../../provider/auth";
 
 suite("provider/auth", () => {
 	teardown(() => {
@@ -150,6 +155,20 @@ suite("provider/auth", () => {
 		} finally {
 			global.fetch = originalFetch;
 		}
+	});
+
+	test("authFailureMessage tailors the 401 message to the auth method", () => {
+		const oauthMsg = authFailureMessage("oauth");
+		assert.ok(/OAuth access token/i.test(oauthMsg), "OAuth message should mention the access token");
+		assert.ok(/token URL|client ID|virtual key/i.test(oauthMsg), "OAuth message should point at OAuth fields");
+		assert.ok(
+			!/configure your API key/i.test(oauthMsg),
+			"OAuth message should not tell the user to configure an API key"
+		);
+
+		const apiKeyMsg = authFailureMessage("apikey");
+		assert.ok(/API key/i.test(apiKeyMsg), "API-key message should mention an API key");
+		assert.ok(!/OAuth/i.test(apiKeyMsg), "API-key message should not mention OAuth");
 	});
 
 	test("a failed token request throws", async () => {


### PR DESCRIPTION
## Summary

Adds **OAuth2 client-credentials** as a per-server authentication method, alongside
the existing static API key. This supports LiteLLM gateways that sit behind an
identity provider and require a short-lived bearer token (plus, optionally, a
"virtual key" client identifier in a custom header) instead of a static key.

Closes #161 

## What changed

When adding or editing a server in **"Manage LiteLLM Provider"**, the user now picks
an authentication method:

- **API Key** — unchanged: static key sent as `Authorization: Bearer <key>` + `X-API-Key`.
- **OAuth (Client Credentials)** — prompts for:
  - **Token URL (IdP)** — the OAuth token endpoint
  - **Client ID** / **Client Secret**
  - **Virtual Key** (optional) + header name (default `X-LLM-API-CLIENT-ID`)

At request time the extension:
1. POSTs `grant_type=client_credentials` (form-encoded) to the token URL.
2. Caches the access token until ~60s before `expires_in`.
3. Sends `Authorization: Bearer <token>` on both model discovery and chat requests,
   plus the optional virtual-key header.

The client secret and virtual key are stored in VS Code's secret storage; the
non-secret fields (token URL, client ID, header name) live in global state next to
the existing server metadata.

## Implementation notes

- New `src/provider/auth.ts` centralizes header resolution (`resolveAuthHeaders`)
  and the token cache; both `discovery.ts` and `client.ts` now consume resolved
  auth headers instead of a raw API key.
- Auth headers take precedence over user-configured custom headers; `Content-Type`
  and `User-Agent` are still forced.
- Switching a server between auth methods cleans up the now-unused secrets and
  clears any cached token.

## Backwards compatibility

Fully backwards compatible. Servers with no explicit auth type are treated as
API-key servers and behave exactly as before; the legacy single-server migration
path is unchanged.

## Checklist

- [ x ] `bun run test` passes
- [ x ] `bun run typecheck` passes
- [ x ] `bun run lint` passes
- [ x ] Docs updated if needed
- [ x ] Follows the conventions in [AGENTS.md](../AGENTS.md)

## Docs

README "Server Management" section updated with an **Authentication methods**
subsection describing both options.