### PR TITLE
fix(reasoning): add Configure Model effort picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ The extension automatically reads token limits from your LiteLLM server's model 
 
 **Priority**: LiteLLM model info → Workspace settings → Defaults
 
+### Reasoning Effort
+
+For models that advertise reasoning support, use **Configure Model** beside the selected model in Chat to choose the
+thinking effort. **Default** adds no picker override; other selections are sent to LiteLLM as `reasoning_effort`.
+
+The control is available in VS Code versions that support per-model configuration. You can continue to set
+`reasoning_effort` in `modelParameters` as a fallback or model-specific default. A value chosen in Configure Model
+overrides `modelParameters`, while an explicit runtime `modelOptions.reasoning_effort` takes highest precedence.
+
 ### Custom Model Parameters (Optional)
 
 Override default request parameters for specific models using the `modelParameters` setting. This is useful for models with specific requirements (like gpt-5 requiring `temperature: 1`) or to customize behavior per model.

--- a/src/provider/client.ts
+++ b/src/provider/client.ts
@@ -13,6 +13,7 @@ import { StreamProcessor } from "./streaming";
 import { resolveServer } from "./config";
 import { getCustomHeaders } from "./httpHeaders";
 import type { ServerWithKey } from "../extension/serverRegistry";
+import { applyReasoningEffortConfiguration } from "./reasoning";
 
 export interface ChatRequestContext {
 	model: LanguageModelChatInformation;
@@ -90,7 +91,7 @@ export async function sendChatRequest(
 		throw new Error("Message exceeds token limit.");
 	}
 
-	const modelParams = getModelParameters(model.id, modelRoutes);
+	const modelParams = applyReasoningEffortConfiguration(getModelParameters(model.id, modelRoutes), options);
 
 	let maxTokens: number;
 	if (typeof options.modelOptions?.max_tokens === "number") {

--- a/src/provider/reasoning.ts
+++ b/src/provider/reasoning.ts
@@ -1,0 +1,85 @@
+import type { LanguageModelChatInformation, ProvideLanguageModelChatResponseOptions } from "vscode";
+import type { LiteLLMProvider } from "../types";
+
+export const REASONING_EFFORTS = ["default", "none", "minimal", "low", "medium", "high", "xhigh"] as const;
+
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+interface LanguageModelConfigurationProperty {
+	type: "string";
+	title: string;
+	enum: readonly ReasoningEffort[];
+	enumItemLabels: readonly string[];
+	enumDescriptions: readonly string[];
+	default: ReasoningEffort;
+	group: "navigation";
+}
+
+interface ConfigurableLanguageModelChatInformation extends LanguageModelChatInformation {
+	readonly configurationSchema?: {
+		readonly properties: {
+			readonly reasoningEffort: LanguageModelConfigurationProperty;
+		};
+	};
+}
+
+interface ConfigurableChatResponseOptions extends ProvideLanguageModelChatResponseOptions {
+	readonly modelConfiguration?: {
+		readonly reasoningEffort?: unknown;
+	};
+}
+
+const reasoningEffortSchema: ConfigurableLanguageModelChatInformation["configurationSchema"] = {
+	properties: {
+		reasoningEffort: {
+			type: "string",
+			title: "Thinking Effort",
+			enum: REASONING_EFFORTS,
+			enumItemLabels: ["Default", "None", "Minimal", "Low", "Medium", "High", "Extra High"],
+			enumDescriptions: [
+				"Use modelParameters when configured, otherwise use the model or provider default.",
+				"Disable reasoning.",
+				"Use no more reasoning than necessary.",
+				"Use low reasoning effort.",
+				"Use medium reasoning effort.",
+				"Use high reasoning effort.",
+				"Use extra-high reasoning effort.",
+			],
+			default: "default",
+			group: "navigation",
+		},
+	},
+};
+
+export function supportsReasoningEffort(provider: LiteLLMProvider): boolean {
+	return (
+		provider.supports_reasoning === true || provider.supported_openai_params?.includes("reasoning_effort") === true
+	);
+}
+
+export function withReasoningEffortConfiguration(
+	info: LanguageModelChatInformation,
+	supported: boolean
+): LanguageModelChatInformation {
+	if (!supported) {
+		return info;
+	}
+	return {
+		...info,
+		configurationSchema: reasoningEffortSchema,
+	} as ConfigurableLanguageModelChatInformation;
+}
+
+export function applyReasoningEffortConfiguration(
+	modelParameters: Record<string, unknown>,
+	options: ProvideLanguageModelChatResponseOptions
+): Record<string, unknown> {
+	const value = (options as ConfigurableChatResponseOptions).modelConfiguration?.reasoningEffort;
+	if (value === "default" || !REASONING_EFFORTS.includes(value as ReasoningEffort)) {
+		return modelParameters;
+	}
+	return {
+		...modelParameters,
+		reasoning_effort: value,
+	};
+}

--- a/src/provider/registration.ts
+++ b/src/provider/registration.ts
@@ -3,6 +3,7 @@ import type { LiteLLMModelItem } from "../types";
 import type { ServerWithKey } from "../extension/serverRegistry";
 import type { ModelRoute } from "./request";
 import { getTokenConstraints, buildExposedModelId } from "./request";
+import { supportsReasoningEffort, withReasoningEffortConfiguration } from "./reasoning";
 
 export interface RegistrationResult {
 	infos: LanguageModelChatInformation[];
@@ -54,20 +55,23 @@ export function buildModelInfos(
 			promptCaching.set(exposedId, providers[0].supports_prompt_caching === true);
 			registerRoute(exposedId, m.id);
 			return [
-				{
-					id: exposedId,
-					name: `${namePrefix}${m.id}`,
-					detail,
-					tooltip: serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM",
-					family: "litellm",
-					version: "1.0.0",
-					maxInputTokens: constraints.maxInputTokens,
-					maxOutputTokens: constraints.maxOutputTokens,
-					capabilities: {
-						toolCalling: providers[0].supports_tools !== false,
-						imageInput: vision,
-					},
-				} satisfies LanguageModelChatInformation,
+				withReasoningEffortConfiguration(
+					{
+						id: exposedId,
+						name: `${namePrefix}${m.id}`,
+						detail,
+						tooltip: serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM",
+						family: "litellm",
+						version: "1.0.0",
+						maxInputTokens: constraints.maxInputTokens,
+						maxOutputTokens: constraints.maxOutputTokens,
+						capabilities: {
+							toolCalling: providers[0].supports_tools !== false,
+							imageInput: vision,
+						},
+					} satisfies LanguageModelChatInformation,
+					supportsReasoningEffort(providers[0])
+				),
 			];
 		}
 
@@ -113,31 +117,43 @@ export function buildModelInfos(
 			const cheapestId = buildExposedModelId(cheapestRaw, server.id, serverCount);
 			const fastestId = buildExposedModelId(fastestRaw, server.id, serverCount);
 
-			entries.push({
-				id: cheapestId,
-				name: `${namePrefix}${m.id} (cheapest)`,
-				detail,
-				tooltip: `LiteLLM via the cheapest provider${serverCount > 1 ? ` on ${server.label}` : ""}`,
-				family: "litellm",
-				version: "1.0.0",
-				maxInputTokens: maxInput,
-				maxOutputTokens: maxOutput,
-				capabilities: aggregateCapabilities,
-			} satisfies LanguageModelChatInformation);
+			const aggregateReasoningEffort = toolProviders.every(supportsReasoningEffort);
+
+			entries.push(
+				withReasoningEffortConfiguration(
+					{
+						id: cheapestId,
+						name: `${namePrefix}${m.id} (cheapest)`,
+						detail,
+						tooltip: `LiteLLM via the cheapest provider${serverCount > 1 ? ` on ${server.label}` : ""}`,
+						family: "litellm",
+						version: "1.0.0",
+						maxInputTokens: maxInput,
+						maxOutputTokens: maxOutput,
+						capabilities: aggregateCapabilities,
+					} satisfies LanguageModelChatInformation,
+					aggregateReasoningEffort
+				)
+			);
 			promptCaching.set(cheapestId, aggregatePromptCaching);
 			registerRoute(cheapestId, cheapestRaw);
 
-			entries.push({
-				id: fastestId,
-				name: `${namePrefix}${m.id} (fastest)`,
-				detail,
-				tooltip: `LiteLLM via the fastest provider${serverCount > 1 ? ` on ${server.label}` : ""}`,
-				family: "litellm",
-				version: "1.0.0",
-				maxInputTokens: maxInput,
-				maxOutputTokens: maxOutput,
-				capabilities: aggregateCapabilities,
-			} satisfies LanguageModelChatInformation);
+			entries.push(
+				withReasoningEffortConfiguration(
+					{
+						id: fastestId,
+						name: `${namePrefix}${m.id} (fastest)`,
+						detail,
+						tooltip: `LiteLLM via the fastest provider${serverCount > 1 ? ` on ${server.label}` : ""}`,
+						family: "litellm",
+						version: "1.0.0",
+						maxInputTokens: maxInput,
+						maxOutputTokens: maxOutput,
+						capabilities: aggregateCapabilities,
+					} satisfies LanguageModelChatInformation,
+					aggregateReasoningEffort
+				)
+			);
 			promptCaching.set(fastestId, aggregatePromptCaching);
 			registerRoute(fastestId, fastestRaw);
 		}
@@ -146,20 +162,25 @@ export function buildModelInfos(
 			const constraints = getTokenConstraints(p);
 			const rawId = `${m.id}:${p.provider}`;
 			const exposedId = buildExposedModelId(rawId, server.id, serverCount);
-			entries.push({
-				id: exposedId,
-				name: `${namePrefix}${m.id} via ${p.provider}`,
-				detail,
-				tooltip: `LiteLLM via ${p.provider}${serverCount > 1 ? ` on ${server.label}` : ""}`,
-				family: "litellm",
-				version: "1.0.0",
-				maxInputTokens: constraints.maxInputTokens,
-				maxOutputTokens: constraints.maxOutputTokens,
-				capabilities: {
-					toolCalling: true,
-					imageInput: vision,
-				},
-			} satisfies LanguageModelChatInformation);
+			entries.push(
+				withReasoningEffortConfiguration(
+					{
+						id: exposedId,
+						name: `${namePrefix}${m.id} via ${p.provider}`,
+						detail,
+						tooltip: `LiteLLM via ${p.provider}${serverCount > 1 ? ` on ${server.label}` : ""}`,
+						family: "litellm",
+						version: "1.0.0",
+						maxInputTokens: constraints.maxInputTokens,
+						maxOutputTokens: constraints.maxOutputTokens,
+						capabilities: {
+							toolCalling: true,
+							imageInput: vision,
+						},
+					} satisfies LanguageModelChatInformation,
+					supportsReasoningEffort(p)
+				)
+			);
 			promptCaching.set(exposedId, p.supports_prompt_caching === true);
 			registerRoute(exposedId, rawId);
 		}
@@ -168,20 +189,25 @@ export function buildModelInfos(
 			const base = providers[0];
 			const constraints = getTokenConstraints(base);
 			const exposedId = buildExposedModelId(m.id, server.id, serverCount);
-			entries.push({
-				id: exposedId,
-				name: `${namePrefix}${m.id}`,
-				detail,
-				tooltip: serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM",
-				family: "litellm",
-				version: "1.0.0",
-				maxInputTokens: constraints.maxInputTokens,
-				maxOutputTokens: constraints.maxOutputTokens,
-				capabilities: {
-					toolCalling: false,
-					imageInput: vision,
-				},
-			} satisfies LanguageModelChatInformation);
+			entries.push(
+				withReasoningEffortConfiguration(
+					{
+						id: exposedId,
+						name: `${namePrefix}${m.id}`,
+						detail,
+						tooltip: serverCount > 1 ? `LiteLLM via ${server.label}` : "LiteLLM",
+						family: "litellm",
+						version: "1.0.0",
+						maxInputTokens: constraints.maxInputTokens,
+						maxOutputTokens: constraints.maxOutputTokens,
+						capabilities: {
+							toolCalling: false,
+							imageInput: vision,
+						},
+					} satisfies LanguageModelChatInformation,
+					supportsReasoningEffort(base)
+				)
+			);
 			promptCaching.set(exposedId, base.supports_prompt_caching === true);
 			registerRoute(exposedId, m.id);
 		}

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -846,6 +846,23 @@ suite("provider", () => {
 			assert.equal(body.top_k, 50);
 		});
 
+		test("forwards Configure Model reasoning effort", async () => {
+			const body = await captureRequestBody(createConfiguredProvider(), modelInfo, {
+				toolMode: vscode.LanguageModelChatToolMode.Auto,
+				modelConfiguration: { reasoningEffort: "high" },
+			});
+			assert.equal(body.reasoning_effort, "high");
+		});
+
+		test("runtime modelOptions override Configure Model reasoning effort", async () => {
+			const body = await captureRequestBody(createConfiguredProvider(), modelInfo, {
+				toolMode: vscode.LanguageModelChatToolMode.Auto,
+				modelConfiguration: { reasoningEffort: "high" },
+				modelOptions: { reasoning_effort: "low" },
+			});
+			assert.equal(body.reasoning_effort, "low");
+		});
+
 		test("does not overwrite provider-owned fields from modelOptions", async () => {
 			const body = await captureRequestBody(createConfiguredProvider(), modelInfo, {
 				toolMode: vscode.LanguageModelChatToolMode.Auto,

--- a/src/test/provider/reasoning.test.ts
+++ b/src/test/provider/reasoning.test.ts
@@ -1,0 +1,102 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { buildModelInfos } from "../../provider/registration";
+import {
+	applyReasoningEffortConfiguration,
+	supportsReasoningEffort,
+	withReasoningEffortConfiguration,
+} from "../../provider/reasoning";
+import type { LiteLLMModelItem, LiteLLMProvider } from "../../types";
+
+interface ConfigurableModelInfo extends vscode.LanguageModelChatInformation {
+	configurationSchema?: {
+		properties?: {
+			reasoningEffort?: {
+				enum?: readonly string[];
+				default?: string;
+				group?: string;
+			};
+		};
+	};
+}
+
+suite("provider/reasoning", () => {
+	const modelInfo: vscode.LanguageModelChatInformation = {
+		id: "reasoning-model",
+		name: "reasoning-model",
+		family: "litellm",
+		version: "1.0.0",
+		maxInputTokens: 1000,
+		maxOutputTokens: 1000,
+		capabilities: {},
+	};
+
+	test("detects reasoning effort from either capability field", () => {
+		const base = { provider: "test", status: "ok" } satisfies LiteLLMProvider;
+		assert.equal(supportsReasoningEffort({ ...base, supports_reasoning: true }), true);
+		assert.equal(supportsReasoningEffort({ ...base, supported_openai_params: ["reasoning_effort"] }), true);
+		assert.equal(supportsReasoningEffort({ ...base, supports_reasoning: false }), false);
+	});
+
+	test("adds the navigation configuration schema only to supported models", () => {
+		const supported = withReasoningEffortConfiguration(modelInfo, true) as ConfigurableModelInfo;
+		const unsupported = withReasoningEffortConfiguration(modelInfo, false) as ConfigurableModelInfo;
+		const property = supported.configurationSchema?.properties?.reasoningEffort;
+
+		assert.equal(property?.group, "navigation");
+		assert.equal(property?.default, "default");
+		assert.deepEqual(property?.enum, ["default", "none", "minimal", "low", "medium", "high", "xhigh"]);
+		assert.equal(unsupported.configurationSchema, undefined);
+	});
+
+	test("applies a valid picker value over model parameters", () => {
+		const params = applyReasoningEffortConfiguration({ reasoning_effort: "low", temperature: 0.5 }, {
+			toolMode: vscode.LanguageModelChatToolMode.Auto,
+			modelConfiguration: { reasoningEffort: "high" },
+		} as vscode.ProvideLanguageModelChatResponseOptions);
+
+		assert.deepEqual(params, { reasoning_effort: "high", temperature: 0.5 });
+	});
+
+	test("keeps model parameters for default or invalid picker values", () => {
+		const configured = { reasoning_effort: "low" };
+		const withDefault = applyReasoningEffortConfiguration(configured, {
+			toolMode: vscode.LanguageModelChatToolMode.Auto,
+			modelConfiguration: { reasoningEffort: "default" },
+		} as vscode.ProvideLanguageModelChatResponseOptions);
+		const withInvalid = applyReasoningEffortConfiguration(configured, {
+			toolMode: vscode.LanguageModelChatToolMode.Auto,
+			modelConfiguration: { reasoningEffort: "turbo" },
+		} as vscode.ProvideLanguageModelChatResponseOptions);
+
+		assert.deepEqual(withDefault, configured);
+		assert.deepEqual(withInvalid, configured);
+	});
+
+	test("shows the picker only when every provider behind aggregate routes supports it", () => {
+		const models: LiteLLMModelItem[] = [
+			{
+				id: "mixed-model",
+				object: "model",
+				created: 0,
+				owned_by: "test",
+				providers: [
+					{ provider: "reasoning", status: "ok", supports_tools: true, supports_reasoning: true },
+					{ provider: "standard", status: "ok", supports_tools: true, supports_reasoning: false },
+				],
+			},
+		];
+		const result = buildModelInfos(
+			models,
+			{ id: "server", label: "Server", baseUrl: "http://test", apiKey: "key" },
+			1,
+			() => {}
+		);
+		const byId = new Map(result.infos.map((info) => [info.id, info as ConfigurableModelInfo]));
+
+		assert.ok(byId.get("mixed-model:reasoning")?.configurationSchema);
+		assert.equal(byId.get("mixed-model:standard")?.configurationSchema, undefined);
+		assert.equal(byId.get("mixed-model:cheapest")?.configurationSchema, undefined);
+		assert.equal(byId.get("mixed-model:fastest")?.configurationSchema, undefined);
+	});
+});


### PR DESCRIPTION
## Summary

- add a Thinking Effort selector to the Chat Configure Model menu for models that advertise reasoning support
- forward the selected value as `reasoning_effort` while preserving runtime and `modelParameters` precedence
- keep aggregate cheapest/fastest entries conservative when provider support is mixed
- document the control and its fallback behavior

## Validation

- `bun run compile`
- `bun run lint` (0 errors; 24 existing warnings)
- `bun run test` (166 passing)

Fixes #177