### PR TITLE
chore: suppress the false-positive password-hash alert on fingerprint()

### DIFF
--- a/src/shared/fingerprint.ts
+++ b/src/shared/fingerprint.ts
@@ -7,5 +7,6 @@ import { createHash } from "node:crypto";
  * keys would share a cached client and put the wrong credentials on the wire.
  */
 export function fingerprint(text: string): string {
+	// codeql[js/insufficient-password-hash] -- not password storage: a non-secret identity for high-entropy API keys
 	return createHash("sha256").update(text).digest("hex").slice(0, 32);
 }


### PR DESCRIPTION
Code scanning flagged [alert #11](https://github.com/Vivswan/litellm-vscode-chat/security/code-scanning/11) (js/insufficient-password-hash) because a value named apiKey flows into SHA-256 in `fingerprint()`. That rule targets stored password authentication, where a slow KDF protects low-entropy user passwords. `fingerprint()` derives a non-secret identity for high-entropy API keys (change detection during the group migration, client caching); an unsalted fast hash is appropriate there, and a 128-bit truncation of SHA-256 does not enable practical key recovery.

The alert is dismissed as a false positive; this adds the matching inline `codeql[...]` suppression comment so the reasoning lives next to the code.