### PR TITLE
chore: restore synced-over security docs and tolerate the stale actionlint scope list

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,3 +29,21 @@ a key.
 <!-- Repository-specific security documentation (scope, threat model, review
      expectations for security-relevant changes) goes below this line. It
      survives template updates via three-way merge. -->
+
+As a small, volunteer-maintained project we cannot commit to a fixed response
+or remediation timeline; acknowledgement and fixes are best-effort.
+
+## Security model and scope
+
+`litellm-vscode-chat` is a VS Code extension that connects VS Code's Language
+Model Chat Provider API to user-configured LiteLLM servers.
+
+- LiteLLM API keys are stored in VS Code SecretStorage. Server labels and
+  base URLs are stored in VS Code global state.
+- The extension sends prompts, tool definitions, and supported attachment
+  data to the LiteLLM server the user configured. Only configure servers you
+  trust.
+- The extension ships no provider API keys; model-provider credentials are
+  managed by the user's LiteLLM deployment.
+- Dependencies are pinned via the committed `bun.lock` and installed with
+  `bun install --frozen-lockfile` in CI and setup scripts.

--- a/scripts/lint-actions.ts
+++ b/scripts/lint-actions.ts
@@ -12,12 +12,18 @@ async function main(): Promise<void> {
 
 	const findings: LintResult[] = [];
 
+	// The npm actionlint wasm build lags the upstream binary; drop findings it
+	// raises only because its permission-scope list is stale (CI runs the
+	// current binary via raven-actions/actionlint, which knows these scopes).
+	const staleScopes = /unknown permission scope "attestations"/;
+
 	for (const file of files) {
 		const input = await fs.readFile(file, "utf8");
 		// A fresh linter per file: reusing one instance grows the WASM memory
 		// across calls until the actionlint wrapper crashes out of bounds.
 		const lint = await createLinter();
-		findings.push(...lint(input, path.relative(process.cwd(), file)));
+		const results = lint(input, path.relative(process.cwd(), file));
+		findings.push(...results.filter((result) => !staleScopes.test(result.message)));
 	}
 
 	if (findings.length === 0) {


### PR DESCRIPTION
Two follow-ups to the template sync in #204:

- SECURITY.md: the sync resolved conflicts toward the template and dropped the best-effort response caveat and the "Security model and scope" section. Both are restored below the template's new repository-specific marker, where future syncs preserve them.
- scripts/lint-actions.ts: the sync added `attestations: write` to ci.yml, a valid permission scope that the npm actionlint wasm build (latest, 2.0.6) does not know yet, which broke the local lint and the husky pre-commit. The wrapper now drops that one stale-scope diagnostic; CI keeps linting with the current actionlint binary via raven-actions.