### PR TITLE
chore: update repo-platform template to staging@1e44504a0d6a

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,9 +1,10 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: 038edd9
+_commit: 1e44504
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.
+fuzzer_label: fuzz-nightly
 github_username: Vivswan
 modules:
 - agents
@@ -12,6 +13,7 @@ modules:
 - issue-templates
 - pr-title
 - auto-assign
+- fuzzer
 private: false
 project_name: LiteLLM VSCode Chat
 project_slug: litellm-vscode-chat


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `038edd9`
- New: `staging@1e44504a0d6a`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.