### PR TITLE
chore: subscribe the settings-sync module

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -4,8 +4,9 @@ _commit: 1e44504
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.
-fuzzer_label: fuzz-nightly
+fuzzer_label: nightly-fuzz
 github_username: Vivswan
+homepage: https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat
 modules:
 - agents
 - bun
@@ -17,3 +18,4 @@ modules:
 private: false
 project_name: LiteLLM VSCode Chat
 project_slug: litellm-vscode-chat
+topics: ai,bun,copilot-chat,litellm,llm,typescript,vscode-extension

--- a/.repo-platform.yml
+++ b/.repo-platform.yml
@@ -2,4 +2,4 @@
 # marks this repository as participating in push sync. `modules` is this
 # repo's module selection - edit it and the next sync applies the change.
 
-modules: ["agents", "bun", "release-please", "issue-templates", "pr-title", "auto-assign", "fuzzer"]
+modules: ["agents", "bun", "release-please", "issue-templates", "pr-title", "auto-assign", "fuzzer", "settings-sync"]


### PR DESCRIPTION
Adds settings-sync to the module list in .repo-platform.yml, so the next fleet sync renders the settings-sync.yml self-apply workflow alongside the existing repo-owned .github/settings.yml.

Two recorded copier answers change with it:

- fuzzer_label is corrected from fuzz-nightly to nightly-fuzz. The deployed nightly-fuzz.yml and settings.yml both use nightly-fuzz; left uncorrected, the first settings render would have declared the wrong label and the label sync would have deleted the one the fuzz-issue dedup keys on.
- homepage and topics are recorded from the live repository values so the settings render keeps managing them.

Self-apply needs a REPO_PLATFORM_TOKEN secret before the new workflow does anything.