### PR TITLE
chore: update repo-platform template to staging@d97a3558d4c6

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: 1e44504
+_commit: d97a355
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.
@@ -15,6 +15,7 @@ modules:
 - pr-title
 - auto-assign
 - fuzzer
+- settings-sync
 private: false
 project_name: LiteLLM VSCode Chat
 project_slug: litellm-vscode-chat

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     cooldown:
       default-days: 7
     # Conventional PR titles so the commit-names/pr-title gates pass; action
-    # bumps are workflow changes, hence ci (toolchain fragments use build).
+    # bumps are workflow changes, hence ci (package-manifest entries use build).
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -75,6 +75,8 @@ labels:
 # the bypass list, so direct pushes to main still work. The single required
 # status check is `all-green` (ci.yml), which `needs:` every gating CI job - the
 # list stays stable when jobs are added or renamed.
+# "Require code quality results" is a public-preview rule with no published
+# REST schema; enable it in the UI (Settings -> Rules -> Rulesets -> main).
 rulesets:
   - name: main
     target: branch

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,13 +1,18 @@
 ---
-# Repository settings, applied from Vivswan/repo-platform's settings-repos
-# run via repo-settings-as-code. Carrying this file is the opt-in for the
-# in-repo settings home; a central settings/repos/litellm-vscode-chat.yml in
-# repo-platform would win over it.
+# Repository settings, applied by Vivswan/repo-platform's
+# central settings-repos run (and, when this file changes, by the
+# settings-sync workflow if the repo carries its own REPO_PLATFORM_TOKEN;
+# without one it skips with a warning). Undeclared labels are deleted;
+# undeclared rulesets are left alone.
+# Rendered by the settings-sync module: template updates keep the
+# baseline current via three-way merge (repo additions survive), and sync
+# NEVER deletes this file - it stays even if the module is deselected. A
+# central settings/repos/<name>.yml in repo-platform wins over it.
 
 repository:
-  description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.
-  homepage: https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat
-  topics: litellm, vscode-extension, copilot-chat, llm, ai, typescript, bun
+  description: "Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM."
+  homepage: "https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat"
+  topics: "ai,bun,copilot-chat,litellm,llm,typescript,vscode-extension"
   has_issues: true
   has_wiki: false
   has_projects: false
@@ -16,6 +21,12 @@ repository:
   allow_squash_merge: true
   allow_merge_commit: false
   allow_rebase_merge: false
+  # The squash subject must ALWAYS be the PR title (the pr-title check and
+  # release-please rely on it); GitHub only defaults to that for
+  # single-commit PRs.
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+  allow_update_branch: true
   delete_branch_on_merge: true
   allow_auto_merge: true
   enable_vulnerability_alerts: true
@@ -25,9 +36,10 @@ labels:
   - name: dependencies
     color: "0366d6"
     description: Dependency updates
-  # Dependabot's default per-ecosystem labels: without a `labels:` override in
-  # dependabot.yml it applies these and recreates them if missing, so leaving
-  # them undeclared would make the settings sync delete/recreate them forever.
+  # Dependabot's default labels: the managed dependabot.yml sets no `labels:`
+  # override, so dependabot applies these and recreates them when missing.
+  # Undeclared they would loop forever: every settings apply deletes what
+  # dependabot re-adds on its next run. Values match what dependabot creates.
   - name: github_actions
     color: "000000"
     description: Pull requests that update GitHub Actions code
@@ -43,12 +55,6 @@ labels:
   - name: fix-lint
     color: "fbca04"
     description: Lint / formatting fixes
-  # nightly-fuzz.yml files the fuzz tracking issue under this label (the
-  # fuzz-issue action keys its one-open-issue dedup on it), so it must
-  # survive the label sync.
-  - name: nightly-fuzz
-    color: "B60205"
-    description: Automated nightly fuzz failure
   # release-please manages these two; listing them here keeps the settings
   # sync from deleting them (it removes any label not declared in this file).
   - name: "autorelease: pending"
@@ -57,13 +63,18 @@ labels:
   - name: "autorelease: tagged"
     color: "ededed"
     description: release-please release PR has been tagged
+  # The nightly-fuzz tracking label (fuzzer module): the fuzz-issue action
+  # keys its one-open-issue-per-label dedup on it, so it must survive the
+  # label sync. Values match what the action creates when the label is absent.
+  - name: "nightly-fuzz"
+    color: "B60205"
+    description: Automated nightly fuzz failure
 
-# Branch ruleset for the default branch. Admins (RepositoryRole id 5) are in the
-# bypass list, so direct pushes to main still work.
-# "Automatically request Copilot code review" is the `copilot_code_review` rule
-# below. "Require code quality results" is NOT yet a documented ruleset rule type
-# (public preview, no published REST schema) -- enable it in the UI
-# (Settings -> Rules -> Rulesets -> main).
+
+# Branch ruleset for the default branch. Admins (RepositoryRole id 5) are in
+# the bypass list, so direct pushes to main still work. The single required
+# status check is `all-green` (ci.yml), which `needs:` every gating CI job - the
+# list stays stable when jobs are added or renamed.
 rulesets:
   - name: main
     target: branch
@@ -82,8 +93,6 @@ rulesets:
           strict_required_status_checks_policy: false
           do_not_enforce_on_create: true
           required_status_checks:
-            # Single aggregate gate (ci.yml `all-green`, which `needs:` every CI
-            # job). Keeps this list stable when matrix jobs are added or renamed.
             - context: all-green
       - type: code_scanning
         parameters:
@@ -95,8 +104,8 @@ rulesets:
         parameters:
           required_approving_review_count: 0
           dismiss_stale_reviews_on_push: false
-          # Require an approving review from a CODEOWNER (.github/CODEOWNERS) before
-          # merge. Admins in bypass_actors can still merge without one.
+          # Require an approving review from a CODEOWNER before merge.
+          # Admins in bypass_actors can still merge without one.
           require_code_owner_review: true
           require_last_push_approval: false
           required_review_thread_resolution: false

--- a/.github/workflows/settings-sync.yml
+++ b/.github/workflows/settings-sync.yml
@@ -1,0 +1,34 @@
+# This file is managed by Vivswan/repo-platform.
+# Local edits may be replaced during template updates.
+#
+# Applies this repository's .github/settings.yml via repo-settings-as-code.
+# Without the REPO_PLATFORM_TOKEN secret the run warns and skips; with
+# one, it needs Administration + Issues write, and a section the token
+# cannot reach fails the run. No heal cron here on purpose:
+# Vivswan/repo-platform's central settings-repos run applies this
+# repository's settings.yml regardless of this workflow.
+
+name: Settings Sync
+
+on:
+  push:
+    branches: [main]
+    paths: [.github/settings.yml]
+  workflow_dispatch:
+    inputs:
+      check_only:
+        description: Report drift without writing
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    uses: Vivswan/repo-platform/.github/workflows/reusable-apply-settings.yml@main
+    with:
+      check_only: ${{ inputs.check_only || false }}
+    secrets:
+      REPO_PLATFORM_TOKEN: ${{ secrets.REPO_PLATFORM_TOKEN }}


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `1e44504`
- New: `staging@d97a3558d4c6`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.

> [!WARNING]
> copier hit merge conflicts, resolved below in favor of the
> template where possible. Restore any dropped local lines that
> should stay, and hand-edit anything marked unresolved, before
> merging.

#### `.github/settings.yml`

Conflict 1: dropped local lines (template version kept):

````
# Repository settings, applied from Vivswan/repo-platform's settings-repos
# run via repo-settings-as-code. Carrying this file is the opt-in for the
# in-repo settings home; a central settings/repos/litellm-vscode-chat.yml in
# repo-platform would win over it.

repository:
  description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.
  homepage: https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat
  topics: litellm, vscode-extension, copilot-chat, llm, ai, typescript, bun
````

Conflict 2: dropped local lines (template version kept):

(none; the local side of the conflict was empty)

Conflict 3: dropped local lines (template version kept):

````
  # Dependabot's default per-ecosystem labels: without a `labels:` override in
  # dependabot.yml it applies these and recreates them if missing, so leaving
  # them undeclared would make the settings sync delete/recreate them forever.
````

Conflict 4: dropped local lines (template version kept):

````
  # nightly-fuzz.yml files the fuzz tracking issue under this label (the
  # fuzz-issue action keys its one-open-issue dedup on it), so it must
  # survive the label sync.
  - name: nightly-fuzz
    color: "B60205"
    description: Automated nightly fuzz failure
````

Conflict 5: dropped local lines (template version kept):

````

# Branch ruleset for the default branch. Admins (RepositoryRole id 5) are in the
# bypass list, so direct pushes to main still work.
# "Automatically request Copilot code review" is the `copilot_code_review` rule
# below. "Require code quality results" is NOT yet a documented ruleset rule type
# (public preview, no published REST schema) -- enable it in the UI
# (Settings -> Rules -> Rulesets -> main).
````

Conflict 6: dropped local lines (template version kept):

````
            # Single aggregate gate (ci.yml `all-green`, which `needs:` every CI
            # job). Keeps this list stable when matrix jobs are added or renamed.
````

Conflict 7: dropped local lines (template version kept):

````
          # Require an approving review from a CODEOWNER (.github/CODEOWNERS) before
          # merge. Admins in bypass_actors can still merge without one.
````