### PR TITLE
chore: update repo-platform template to staging@facc3d6127a4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: '8816965'
+_commit: facc3d6
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,28 @@ jobs:
       - uses: actions/checkout@v7
       - uses: raven-actions/actionlint@v2
 
+  # Secret scanning: a committed credential fails the gate. The action
+  # scans the event's commit range (fetch-depth: 0 so any range
+  # resolves); audit the OLD history once with a local `gitleaks git`.
+  # Personal-account repos need no GITLEAKS_LICENSE; allowlist false
+  # positives in a repo-owned .gitleaks.toml at the repository root.
+  # pull-requests read: the action lists the PR's commits to build the
+  # scan range. Comments off keeps that scope at read; leaks still land
+  # in the job summary and SARIF artifact.
+  gitleaks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+
   yamllint:
     runs-on: ubuntu-latest
     steps:
@@ -118,6 +140,7 @@ jobs:
       - typography
       - commit-names
       - actionlint
+      - gitleaks
       - yamllint
       - codeql-javascript
       - pr-title


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `8816965`
- New: `staging@facc3d6127a4`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.