### PR TITLE
chore: update repo-platform template to staging@cfdc11a935a6

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: facc3d6
+_commit: cfdc11a
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 description: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered by LiteLLM.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -35,6 +35,13 @@ repository:
   allow_auto_merge: true
   enable_vulnerability_alerts: true
   enable_automated_security_fixes: true
+  # Declared so the apply heals out-of-band disables. Public only: without
+  # Advanced Security, private repositories reject this block (422).
+  security_and_analysis:
+    secret_scanning:
+      status: enabled
+    secret_scanning_push_protection:
+      status: enabled
 
 labels:
   - name: dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
   # scans the event's commit range (fetch-depth: 0 so any range
   # resolves); audit the OLD history once with a local `gitleaks git`.
   # Personal-account repos need no GITLEAKS_LICENSE; allowlist false
-  # positives in a repo-owned .gitleaks.toml at the repository root.
+  # positives in the repo-owned .gitleaks.toml at the repository root
+  # (seeded by the template, never overwritten by sync).
   # pull-requests read: the action lists the PR's commits to build the
   # scan range. Comments off keeps that scope at read; leaks still land
   # in the job summary and SARIF artifact.
@@ -86,10 +87,14 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_COMMENTS: "false"
+          # The action's default binary (8.24.3) predates .gitleaks.toml's
+          # minVersion floor AND skips that check silently; pin one meeting
+          # the floor so CI honors the same config local runs do.
+          GITLEAKS_VERSION: "8.30.1"
 
   yamllint:
     runs-on: ubuntu-latest
@@ -99,6 +104,24 @@ jobs:
         run: python3 -m pip install --quiet yamllint
       - name: Lint YAML
         run: yamllint -s .
+
+  # Fails when a PR introduces dependencies with known vulnerabilities, by
+  # diffing the dependency graph between base and head. Public renders only:
+  # the dependency-graph API behind it is free just for public repositories.
+  # Only PR events have a diff to review, so the skip lives on the steps:
+  # all-green treats a skipped needed job as failure, so the job itself
+  # stays unconditional.
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request'
+      - uses: actions/dependency-review-action@v5
+        if: github.event_name == 'pull_request'
+        with:
+          # Deliberate strictest threshold (also the action's default,
+          # pinned so a default change cannot loosen the gate silently).
+          fail-on-severity: low
 
   # CodeQL analysis runs inside the gate (one job per language), so a failed
   # scan blocks merges. Each job grants the scan permissions - a caller
@@ -114,6 +137,34 @@ jobs:
       security-events: write
       actions: read
 
+
+  # Fails when the release-please PR head lacks main's tip at CHECK time:
+  # a stale release PR cuts a release whose version and changelog miss
+  # commits already on main. A main push after this run is only caught by
+  # release-please's refresh re-running CI. Other PRs stay mergeable while
+  # behind (required checks are not strict). The skip lives on the STEPS:
+  # all-green treats a skipped needed job as failure.
+  release-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--')
+        with:
+          # Full history: the ancestor check needs origin/main.
+          fetch-depth: 0
+          # PR head, not the default merge ref - the merge ref already
+          # contains main's tip, so it would always pass.
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Require the release PR to contain the tip of main
+        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--')
+        run: |
+          tip="$(git rev-parse "origin/${GITHUB_BASE_REF}")"
+          if git merge-base --is-ancestor "$tip" HEAD; then
+            echo "release PR contains the ${GITHUB_BASE_REF} tip (${tip})"
+          else
+            echo "::error::Release PR is behind ${GITHUB_BASE_REF} (tip ${tip}); its version and changelog would miss commits already on ${GITHUB_BASE_REF}. Do not merge; release-please refreshes the PR after the next green run on ${GITHUB_BASE_REF}."
+            exit 1
+          fi
 
   # Conventional Commit PR title, checked inside the gate so branch
   # protection blocks on it. PRs are squash-merged, so the PR title becomes
@@ -142,7 +193,9 @@ jobs:
       - actionlint
       - gitleaks
       - yamllint
+      - dependency-review
       - codeql-javascript
+      - release-freshness
       - pr-title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependabot-bun-lockfile.yml
+++ b/.github/workflows/dependabot-bun-lockfile.yml
@@ -56,11 +56,11 @@ jobs:
       # Every tracked lockfile, not just the root one: a repository can
       # commit several (repo-platform itself locks each composite action's
       # directory). '*/bun.lock' is a git pathspec, where '*' crosses '/',
-      # so it matches at any depth. Deleting before regenerating matters: bun accepts the
-      # stale lockfile as a valid resolution and keeps it, so only a
-      # from-scratch resolve drops the stale entries. The side effect is a
-      # refresh of every in-range pin, which package.json ranges and the
-      # PR's own CI still bound.
+      # so it matches at any depth. Deleting before regenerating matters:
+      # bun accepts the stale lockfile as a valid resolution and keeps it,
+      # so only a from-scratch resolve drops the stale entries. The side
+      # effect is a refresh of every in-range pin, which package.json
+      # ranges and the PR's own CI still bound.
       - name: Regenerate bun lockfiles
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ LiteLLM VSCode Chat: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered b
 
 <!-- Add project-specific instructions below. This section survives template
      updates via three-way merge. -->
+<!-- repo-platform:local-section -->
 
 Keep shared project facts here; the code is the source of truth for
 implementation detail.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the project owner's GitHub profile ([github.com/Vivswan](https://github.com/Vivswan)). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,7 @@ a key.
 <!-- Repository-specific security documentation (scope, threat model, review
      expectations for security-relevant changes) goes below this line. It
      survives template updates via three-way merge. -->
+<!-- repo-platform:local-section -->
 
 For this extension, the latest release means the latest VS Code Marketplace
 release; the tip of `main` is supported too. The project is pre-1.0, so


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `facc3d6`
- New: `staging@cfdc11a935a6`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.

> [!WARNING]
> copier hit merge conflicts, resolved below in favor of the
> template where possible. Restore any dropped local lines that
> should stay, and hand-edit anything marked unresolved, before
> merging.

#### `AGENTS.md`

Conflict 1: local lines moved below the repository-specific marker (template side kept in place):

````

Keep shared project facts here; the code is the source of truth for
implementation detail.

### Project overview

A VS Code extension that integrates LiteLLM into GitHub Copilot Chat via the Language Model Chat Provider API: streaming chat with tool calling, multimodal input, thinking/reasoning, and multiple LiteLLM servers at once.

### Commands

```bash
bun run setup-env          # install dependencies (setup-env:pwsh on Windows PowerShell)
bun run compile            # tsc to out/ (tests run from here)
bun run bundle             # production bundles (bundle:dev for unminified)
bun run typecheck          # all four tsconfig projects
bun run lint               # Biome (lint:types, lint:knip, lint:actions for the others)
bun run test               # webview suite, then unit + activation-production + capture host-fidelity in the extension host (test:coverage adds the floor)
bun run test:docker        # docker suites + stream fuzzer against a real LiteLLM proxy (--only <labels> runs a subset)
bun run docker:up          # local LiteLLM proxy + fake OpenAI backend (docker:down, docker:logs)
bun run generate-config    # print the generated LiteLLM proxy config to stdout (stack startup writes the real file)
bun run dev                # Extension Development Host preconfigured against the fake stack
```

### Validation expectations for agents

- After TypeScript changes: `bun run compile`; when scripts/ changed, `bun run typecheck`.
- After source or test changes: `bun run lint`, `bun run lint:types`, `bun run lint:knip`, and the relevant tests. After workflow changes: `bun run lint:actions`.
- Never launch VS Code or any GUI for verification; humans test interactively (`F5` or `bun run dev`).

### Architecture

Four source trees with Biome-enforced layering: `src/extension/` (activation, commands, UI surfaces) may import the others; `src/provider/` (the `LanguageModelChatProvider` and transport) must not import the extension layer; `src/shared/` imports neither; `src/webview/` (the dashboard's Preact UI, own tsconfig, bundled separately to `dist/webview/dashboard.js`) may import only the dashboard protocol modules and talks to the extension over the panel's message protocol. Inside those trees: `src/provider/transport/` holds the wire-facing request, streaming, and error machinery, `src/provider/catalog/` holds discovery, registration, and model metadata (with `provider/config.ts` staying at the root as the extension-injection seam), `src/shared/conversion/` holds the VS Code-to-OpenAI message, tool, and token conversions, `src/shared/util/` and `src/shared/config/` hold the small helpers and the settings/commands/storage-keys declarations (everything else shared stays at the root), `src/extension/servers/` holds the server registry, server management, and the serverSync engine, and `src/extension/ui/` holds the command surfaces: commands, notifier, status bar, and the issue reporter with its diagnostics-snapshot builder (dashboard/ and migrations/ stay where they are). Helper scripts are grouped by role: `scripts/stack/` (compose wrapper, proxy config generation, the fake OpenAI backend), `scripts/dev/` (dev launcher, esbuild, third-party notices), `scripts/env/` (setup-env), and `scripts/ci/`, with `scripts/docker-test.ts` at the root as the docker-suite orchestrator; the compose file itself lives at `docker/docker-compose.yml`.

Two deliberate design contracts worth knowing before touching transport code: streaming parses the raw response body itself instead of using the SDK's stream parser, because the contract is log-and-skip on malformed SSE lines with observable aborts, and `parseChunk`'s leniency rules are pinned by tests. `console.*` is banned in `src/` outside tests; logs also feed the issue-report buffer that opens public GitHub issues, so log classifications, never response-derived text. `src/shared/config/parameterResolution.ts` is the single owner of modelParameters prefix resolution, the precedence merge, and the max_tokens fallback branch: the request path and the dashboard's effective-values inspector both consume it, and a seed-pinned equivalence property pins the two sides against buildRequestBody.

Storage migrations live in `src/extension/migrations/`: state-detecting and idempotent (each one reruns every activation and no-ops once its legacy state is gone), with all logic touching legacy identifiers quarantined there, while the keys themselves stay in `shared/config/storageKeys.ts`.

### Load-bearing invariants

- **Request pass-through.** Beyond the provider-owned request fields (`model`, `messages`, `stream`, `stream_options` with `include_usage`, `max_tokens`, and, when tools are in play, `tools`/`tool_choice`), the extension never injects a request parameter the user did not set: no default temperature, no allow-list. Provider-owned fields cannot be overridden; keys starting with `_` are skipped; everything else from `modelParameters` config and runtime `modelOptions` reaches LiteLLM unchanged. A declared server entry may carry its own `modelParameters` (same prefix-keyed shape, no server scoping), applied only to requests routed through a group server whose label and base URL both match that entry; entry parameters count as user-set and override the global setting key by key. The host-resolved per-model configuration (Configure Model picks, e.g. reasoning effort) counts as user-set and is forwarded likewise, except only schema-declared properties go out (mapped to their wire keys). The full precedence chain is: runtime options > picker configuration > entry `modelParameters` > global `modelParameters`. One documented exception: when neither runtime options nor config set `max_tokens`, the request carries the model's declared max output tokens as-is, or `min(4096, model max output tokens)` when that number is a guess (`defaultMaxOutputTokens`, an OpenRouter catalog match, or the built-in floor); a user-set `modelCapabilities` override counts as declared (`outputLimitSource: "user"` lifts the cap), and a merged deployment's or aggregate's minimum counts as declared only if every contributor declared one.
- **Capabilities vs parameters.** Capabilities (what a model can do) are read from the LiteLLM API and drive registration and token constraints, corrected and extended by user-set `modelCapabilities` (global setting and per-entry field, same prefix-and-scoping mechanics as `modelParameters` but a closed vocabulary, owned by `src/shared/config/capabilityResolution.ts` - registration and the dashboard's capability inspector consume the same resolver). `_declare: true` on a server-scoped or entry key creates that exact model ID when discovery cannot list it (inert when discovery does); OpenRouter catalog data backfills fields nothing user-set or server-reported provides - via an explicit `_openrouter_model` directive (above the server-reported level) or an implicit exact-ID match (a low-precedence fallback). Parameters (what we ask it to do) come only from user config, the model picker's per-model configuration, and runtime options. `modelParameters` uses longest-prefix matching with optional server scoping (base URL prefix).
- **Retries.** Discovery GETs retry (idempotent), except an endpoint named in the entry's `expectedFailures` (`modelListing` for the models listing, `modelInfo` for model info), which gets a single attempt; chat completions never retry. The configured timeouts are hard whole-call bounds.
- **Error ownership.** Transport modules (`provider/catalog/discovery.ts`, `provider/transport/chatClient.ts`, `provider/transport/auth.ts`, `shared/validation.ts`) construct specific errors and throw without logging; the provider boundary (`src/provider/index.ts`) logs once. Cancellation surfaces as `vscode.CancellationError` and is never logged. Silent refreshes return an empty model list instead of throwing, except that a silent group refresh whose last successful discovery is under ten minutes old returns the group's last known models flagged stale (warning icon plus hover warning). 401s are never re-wrapped as network errors.
- **Storage.** The `servers` setting is declarative truth that `extension/servers/serverSync/` syncs to host provider groups; it is machine-scoped (user settings only, so workspaces cannot re-point a label at another host), and its secret fields may sit inline in the setting or, per entry, under the `serverSecrets` SecretStorage keys, with inline winning. The legacy registry is the pre-migration location - server URLs in `globalState`, per-server API keys in SecretStorage - and serves only until the provider-group migration completes (permanently in non-production mode). User options live in `litellm-vscode-chat.*` settings; every Memento/SecretStorage key lives in `shared/config/storageKeys.ts`. The OpenRouter catalog cache is a JSON file under `globalStorage`: the file is the truth, and the globalState key beside it holds only advisory refresh metadata (globalState is not transactional). Credentials of externally managed provider groups (created in the native editor, not from a declared entry) are host-owned (declared in the `languageModelChatProviders` contribution) and never duplicated into extension storage; the one exception is the user-initiated adopt action, which copies such a group's credentials into the new declared entry's storage, while the host group keeps its own copy. The dashboard's state pushes carry secret locations, never values; the one value path to the webview is the edit form's on-demand prefill of inline-stored fields (already plaintext in the settings file), and secure-side values never render.
- **Multi-server IDs.** Servers live in VS Code-managed provider groups: the host calls the provider once per group with its configuration, and the resolved server rides on each returned model object (raw IDs; the host namespaces them). The legacy registry path still serves configuration-less refreshes until migration completes, and permanently in non-production mode, where the `litellm._test.*` commands and the host-fidelity suite depend on it.

### Localization

Two runtime APIs, one mechanical boundary: host-only code (`src/extension.ts`, `src/extension/**`, `src/provider/**`) localizes with `vscode.l10n.t`; `src/webview/**`, the three dashboard-shared modules `protocol.ts`/`recordDraft.ts`/`serverForm.ts`, and `src/shared/**` import `@vscode/l10n`. The reason is the webview bundle, not import legality: parts of shared ride into `dist/webview/dashboard.js` through protocol.ts re-exports, and `@vscode/l10n` is the one l10n API that works in both runtimes. Biome's noRestrictedImports enforces the split both ways (the dashboard-shared modules also may not import `vscode`), and no facade may re-export either API - `@vscode/l10n-dev` extraction only recognizes the two canonical forms. Both APIs read the same `l10n/bundle.l10n.<locale>.json` files: `src/extension/l10nConfig.ts` (the one sanctioned host-side `@vscode/l10n` import) feeds `vscode.l10n.bundle` into `@vscode/l10n` at the top of activate(), and the dashboard HTML shell injects the same bundle as `window.__l10nBundle` for the webview.

No localized module-level constants: modules load before the bundle is configured, so presentation strings resolve at call time (zero-arg functions like `manageCommandTitle()`). Plurals pick between two literal keys at the call site - `n === 1 ? t("1 model") : t("{0} models", n)` - and interpolation goes through `{0}` args, never `${}` inside `t()`, so extraction sees every literal.

Stays English by policy: logger output and `logClassification`/`markLogSafe`, the issue-report body and diagnostics snapshot, `overallStatusText`/`serverOutcomeText`/`ENTRY_PARAMS_INACTIVE_TEXT` (users paste those lines into issue reports), and brand or protocol terms (LiteLLM, GitHub Copilot Chat, OAuth, header names, setting IDs, model IDs, URLs). Anything that throws a localized Error into the status or provider-boundary log path must carry an English mirror (`englishMessage` via `localizedError`/`RequestError`, or a terse `logClassification`) - a bare localized message (say, if `shared/validation.ts` ever localizes) would land translated text in the output channel and public issue reports.

Workflow: after adding or changing localized strings, `bun run l10n:extract` regenerates the key-sorted `l10n/bundle.l10n.json`; `bun run l10n:check` (pre-commit and CI) fails on extraction drift, key-set or `{0}`-placeholder mismatches in any `bundle.l10n.*.json` or `package.nls.*.json`, banned typography in translation files, and `%key%` coverage between package.json and package.nls.json. Chinese translations keep ASCII punctuation plus the CJK full stop, enumeration comma, and corner brackets; fullwidth ASCII variants, ideographic space, curly quotes, ellipsis, and em/en dashes are banned.

### Repository conventions

- Biome formats and lints: tabs (width 2), semicolons, 120-char lines. Husky pre-commit runs format, lint, actionlint, scripts typecheck, and the unit and capture host-fidelity suites; it runs `biome check --write` repo-wide and aborts the commit when that modifies anything, so re-stage and commit again.
- release-please manages versioning and Marketplace publishing from Conventional Commit titles. Never bump `package.json` manually.
- A commit that resolves a community-reported issue or supersedes a community PR credits the author in its subject, e.g. `fix: normalize base URL slashes (#53, thanks @Pandaplanes)` - release-please copies the subject into the changelog, so the credit ships with the release. Commits that land or supersede community CODE also carry a human `Co-authored-by:` trailer and a row in `ACKNOWLEDGMENTS.md`.
- No AI/tool attribution in commits or PRs: no "Generated with", no "Co-Authored-By: Claude/Copilot/Codex" or similar. `Co-authored-by:` trailers for human community contributors are the one sanctioned use.

### Code review guidance

Prioritize correctness, security, regressions, missing tests, and violations of this document. Report concrete findings tied to the changed code; skip style Biome already enforces. Pay particular attention to streaming responses, tool-call pairing, multimodal conversion, token limits, request-field ownership, and secret handling (storage, logs, and the webview boundary).

### Testing

Tests mirror the source layout under `src/test/` and run in the extension host (`@vscode/test-cli` via `.vscode-test.mjs`, Mocha tdd; entry points build the bundle first). `.vscode-test.mjs` accepts positive globs only (it ignores `!` negations), and stackDrift's label-coverage guard pins every compiled test file to exactly one label. Network mocking uses msw (`src/test/mocks/handlers.ts` documents its quirks), with `withFetch` for what msw cannot express. Property suites (fast-check) are seed-pinned and scale with `FUZZ_RUNS`. Docker suites drive the fake stack through its chat-input command grammar (`src/test/fakeStack/commands.ts`; `%play:<name>` selects a canned stream shape from `src/test/scenarios.ts`). The model catalog in `src/test/fakeStack/models.ts` is the source of truth for the proxy config, generated at stack startup (`docker/.generated/litellm-config.yaml`, gitignored; the test orchestrator always generates it without real-provider wildcard routes). Pin any fuzz-found failure in `src/test/fuzzCorpus.ts`. `COMPOSE_CMD` overrides docker/podman detection.

The one exception to the extension-host rule is the webview suite (`src/test/webview/`, `bun run test:webview`): bun test with happy-dom rendering the dashboard's Preact components directly. `bunfig.toml`'s `[test] root` confines bare `bun test` to that directory - the Mocha-tdd suites crash under bun's runner - and its preload registers the DOM plus the `acquireVsCodeApi` stub before any component import. The suite renders source `.tsx`, not the esbuild bundle; the packaged-file-list check's size floor on `dist/webview/dashboard.js` guards the bundling side.

### CI

Repo-owned jobs live in `checks.yml` inside the required all-green gate: the full `bun run test` pass (webview, unit, activation-production, and capture host-fidelity suites) on three OSes with a Linux coverage floor, the promoted docker-stack suite (docker suites, stream fuzzer, and live host-fidelity against the dockerized proxy, split into two time-balanced shards via `test:docker --only`), an elevated fuzz pass that runs only when the diff touches fuzzer-related paths (skipped otherwise, which the gate counts as green; one unit job plus a sharded docker job), and the format-check workflow (including the packaged-file-list check). `docker-test.yml` is a workflow_dispatch-only wrapper; `nightly-fuzz.yml` runs the docker and property suites at high iteration counts and files `nightly-fuzz` issues with reproduction seeds; `release.yml` publishes the VSIX after release-please cuts a release.
````

#### `CONTRIBUTING.md`

Conflict 1: local lines moved below the repository-specific marker (template side kept in place):

````

## Prerequisites

- [Bun](https://bun.sh): package manager and runtime
- VS Code: required by the extension test harness

## Setup

On macOS, Linux, or any shell with Bash available:

```bash
git clone https://github.com/<your-fork>/litellm-vscode-chat.git
cd litellm-vscode-chat
bun run setup-env
```

On Windows without Bash, use PowerShell instead:

```powershell
git clone https://github.com/<your-fork>/litellm-vscode-chat.git
cd litellm-vscode-chat
bun run setup-env:pwsh
```

## Running checks

From the project directory:

```bash
bun run lint:actions # lint GitHub Actions workflows
bun run lint         # run Biome lint
bun run compile      # compile TypeScript
bun run test         # run the VS Code extension tests
bun run format       # format files with Biome
```

A Husky pre-commit hook runs formatting, workflow linting, source linting, and tests when dependencies are installed.

## Code style

Conventions live in [AGENTS.md](AGENTS.md). In short:

- Biome enforces formatting and TypeScript lint rules.
- Keep changes focused and avoid unrelated fixes.

## Submitting a pull request

1. Fork the repo and create a branch for your change.
2. Make sure the checks under "Running checks" pass locally.
3. Open a PR with a Conventional Commit title (see "Pull requests" above).
````

#### `SECURITY.md`

Conflict 1: local lines moved below the repository-specific marker (template side kept in place):

````

For this extension, the latest release means the latest VS Code Marketplace
release; the tip of `main` is supported too. The project is pre-1.0, so
security fixes land on `main` and go out through the normal release flow.
Keep security reports out of public pull requests and discussions as well as
issues.

As a small, volunteer-maintained project we cannot commit to a fixed response
or remediation timeline; acknowledgement and fixes are best-effort.

## Security model and scope

`litellm-vscode-chat` is a VS Code extension that connects VS Code's Language
Model Chat Provider API to user-configured LiteLLM servers.

- LiteLLM API keys are stored in VS Code SecretStorage. Server labels and
  base URLs are stored in VS Code global state.
- The extension sends prompts, tool definitions, and supported attachment
  data to the LiteLLM server the user configured. Only configure servers you
  trust.
- The extension ships no provider API keys; model-provider credentials are
  managed by the user's LiteLLM deployment.
- Dependencies are pinned via the committed `bun.lock` and installed with
  `bun install --frozen-lockfile` in CI and setup scripts.
````