### PR TITLE
chore: select the custom-license module

### DIFF
--- a/.repo-platform.yml
+++ b/.repo-platform.yml
@@ -2,4 +2,4 @@
 # marks this repository as participating in push sync. `modules` is this
 # repo's module selection - edit it and the next sync applies the change.
 
-modules: ["agents", "bun", "release-please", "issue-templates", "pr-title", "auto-assign", "fuzzer", "settings-sync"]
+modules: ["agents", "bun", "release-please", "issue-templates", "pr-title", "auto-assign", "fuzzer", "settings-sync", "custom-license"]


### PR DESCRIPTION
This repository stays MIT: it carries community-authored code landed under MIT, which the fleet license cannot replace. The `custom-license` module makes `LICENSE` repo-owned, so template syncs never touch it.

Must merge before any `recover=recopy` sync dispatch targets this repository.