### PR TITLE
chore: update repo-platform template to staging@ce948109380e

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: 74296e4
+_commit: ce94810
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 copyright_holder: Vivswan Shah (https://github.com/Vivswan)

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,9 +7,6 @@ CLAUDE.md -text
 .github/copilot-instructions.md -text
 .github/agents.md -text
 
-# Render the extensionless LICENSE as Markdown on GitHub.
-LICENSE linguist-language=Markdown
-
 # Keep binary assets byte-for-byte unchanged.
 *.ico binary
 *.jpg binary
@@ -19,4 +16,9 @@ LICENSE linguist-language=Markdown
 *.webp binary
 *.pdf binary
 *.zip binary
+
+# Repository-specific attributes (binary globs, linguist overrides) go
+# below this line. They survive template updates via three-way merge.
+# repo-platform:local-section
+
 *.vsix binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
   # scan blocks merges. Each job grants the scan permissions - a caller
   # job's permissions are the ceiling for the called workflow - and the
   # weekly re-scan schedule lives on this workflow's triggers.
+  # Repo-specific scan tuning (paths-ignore, extra queries, packs) goes in
+  # the repo-owned .github/codeql/codeql-config.yml - the standard CodeQL
+  # config file, picked up automatically when present.
 
   codeql-javascript:
     uses: Vivswan/repo-platform/.github/workflows/reusable-codeql.yml@main

--- a/.github/workflows/format-check-reusable.yml
+++ b/.github/workflows/format-check-reusable.yml
@@ -94,7 +94,7 @@ jobs:
           # noticed). Anything new must be added here deliberately, including
           # new asset types and new localization catalogs. POSIX bracket
           # expressions treat \w literally, hence the spelled-out class.
-          allowed='^(package\.json|README\.md|CHANGELOG\.md|LICENSE|ThirdPartyNotices\.txt|dist/extension\.js|dist/webview/dashboard\.js|dist/openrouter-models\.json)$|^assets/.+\.(png|md)$|^package\.nls(\.[A-Za-z0-9_-]+)?\.json$|^l10n/bundle\.l10n(\.[A-Za-z0-9_-]+)?\.json$'
+          allowed='^(package\.json|README\.md|CHANGELOG\.md|LICENSE\.md|ThirdPartyNotices\.txt|dist/extension\.js|dist/webview/dashboard\.js|dist/openrouter-models\.json)$|^assets/.+\.(png|md)$|^package\.nls(\.[A-Za-z0-9_-]+)?\.json$|^l10n/bundle\.l10n(\.[A-Za-z0-9_-]+)?\.json$'
           if echo "$listing" | grep -Ev "$allowed"; then
             echo "::error::vsce would package files outside the allowed set (matches above)"
             exit 1

--- a/.typography-allow
+++ b/.typography-allow
@@ -5,3 +5,4 @@
 # release-please writes CHANGELOG.md from commit and PR text, which is not
 # ASCII-guaranteed.
 CHANGELOG.md
+# END REPO-PLATFORM MANAGED

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,11 +41,12 @@ LiteLLM VSCode Chat: Use 100+ LLMs in VS Code with GitHub Copilot Chat powered b
   `settings/repos/` file named after this repository over there when one
   exists, otherwise by this repository's own `.github/settings.yml`. Do not
   change settings by hand in the GitHub UI; edit the settings file.
-- Repo-owned escape hatches stay local: `.github/workflows/checks.yml` and
-  `.github/workflows/release.yml`, `.gitignore`'s marked LOCAL section,
-  `.typography-allow.local` (typography exemptions; the managed
-  `.typography-allow` is overwritten by sync), and the repository-specific
-  section below.
+- Repo-owned escape hatches stay local:
+  `.github/workflows/checks.yml`,
+  `.github/workflows/release.yml`, `.gitleaks.toml`,
+  `.gitignore`'s marked LOCAL section, `.typography-allow.local`
+  (typography exemptions; the managed `.typography-allow` is overwritten
+  by sync), and the repository-specific section below.
 - Module selection is this repository's own: edit the `modules` list in
   `.repo-platform.yml` and the next sync PR applies the change.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ local edits to managed files are replaced on the next template sync.
   versioned from these subjects.
 - By opening a pull request, or offering code in an issue or review for
   inclusion, you agree to the Contributions section of the
-  [LICENSE](LICENSE), which licenses that code to the licensor -
+  [LICENSE](LICENSE.md), which licenses that code to the licensor -
   including for relicensing under any terms - unless you conspicuously
   say otherwise when you submit it.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -344,35 +344,3 @@ licenses.
      third-party components, differently licensed paths) go below this
      line. They survive template updates via three-way merge. -->
 <!-- repo-platform:local-section -->
-
-## Prior MIT License
-
-Before the terms above were adopted, this software was offered under
-the MIT License: every release through v0.4.4, and every contribution
-submitted up to that adoption, was made under it. Those portions remain
-available under the MIT License; their copyright and permission notice
-is preserved below.
-
-> MIT License
->
-> Copyright (c) 2025 Vivswan Shah and litellm-vscode-chat contributors
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-> BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-> ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-> CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -344,3 +344,35 @@ licenses.
      third-party components, differently licensed paths) go below this
      line. They survive template updates via three-way merge. -->
 <!-- repo-platform:local-section -->
+
+## Prior MIT License
+
+Before the terms above were adopted, this software was offered under
+the MIT License: every release through v0.4.4, and every contribution
+submitted up to that adoption, was made under it. Those portions remain
+available under the MIT License; their copyright and permission notice
+is preserved below.
+
+> MIT License
+>
+> Copyright (c) 2025 Vivswan Shah and litellm-vscode-chat contributors
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+> BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+> ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+> CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Individual and Small Organization License 1.0.0
 
-<https://github.com/Vivswan/repo-platform/blob/main/LICENSE>
+<https://github.com/Vivswan/repo-platform/blob/main/LICENSE.md>
 
 Required Notice: Copyright Vivswan Shah (https://github.com/Vivswan)
 
@@ -344,35 +344,3 @@ licenses.
      third-party components, differently licensed paths) go below this
      line. They survive template updates via three-way merge. -->
 <!-- repo-platform:local-section -->
-
-## Prior MIT License
-
-Before the terms above were adopted, this software was offered under
-the MIT License: every release through v0.4.4, and every contribution
-submitted up to that adoption, was made under it. Those portions remain
-available under the MIT License; their copyright and permission notice
-is preserved below.
-
-> MIT License
->
-> Copyright (c) 2025 Vivswan Shah and litellm-vscode-chat contributors
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-> BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-> ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-> CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Installs](https://vsmarketplacebadges.dev/installs/vivswan.litellm-vscode-chat.svg)](https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat)
 [![Rating](https://vsmarketplacebadges.dev/rating-short/vivswan.litellm-vscode-chat.svg)](https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat&ssr=false#review-details)
 [![CI](https://github.com/Vivswan/litellm-vscode-chat/actions/workflows/ci.yml/badge.svg)](https://github.com/Vivswan/litellm-vscode-chat/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Individual%20%26%20Small%20Org%201.0.0-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-Individual%20%26%20Small%20Org%201.0.0-blue)](LICENSE.md)
 
 English | [简体中文](README.zh-cn.md) | [繁體中文](README.zh-tw.md)
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -4,7 +4,7 @@
 [![Installs](https://vsmarketplacebadges.dev/installs/vivswan.litellm-vscode-chat.svg)](https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat)
 [![Rating](https://vsmarketplacebadges.dev/rating-short/vivswan.litellm-vscode-chat.svg)](https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat&ssr=false#review-details)
 [![CI](https://github.com/Vivswan/litellm-vscode-chat/actions/workflows/ci.yml/badge.svg)](https://github.com/Vivswan/litellm-vscode-chat/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Individual%20%26%20Small%20Org%201.0.0-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-Individual%20%26%20Small%20Org%201.0.0-blue)](LICENSE.md)
 
 [English](README.md) | 简体中文 | [繁體中文](README.zh-tw.md)
 

--- a/README.zh-tw.md
+++ b/README.zh-tw.md
@@ -6,7 +6,7 @@
 [![Installs](https://vsmarketplacebadges.dev/installs/vivswan.litellm-vscode-chat.svg)](https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat)
 [![Rating](https://vsmarketplacebadges.dev/rating-short/vivswan.litellm-vscode-chat.svg)](https://marketplace.visualstudio.com/items?itemName=vivswan.litellm-vscode-chat&ssr=false#review-details)
 [![CI](https://github.com/Vivswan/litellm-vscode-chat/actions/workflows/ci.yml/badge.svg)](https://github.com/Vivswan/litellm-vscode-chat/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Individual%20%26%20Small%20Org%201.0.0-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-Individual%20%26%20Small%20Org%201.0.0-blue)](LICENSE.md)
 
 透過 [LiteLLM](https://docs.litellm.ai) 在 VS Code 中與 GitHub Copilot Chat 搭配使用 100 多個 LLM。
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "%litellm.description%",
 	"version": "0.4.4",
 	"publisher": "vivswan",
-	"license": "SEE LICENSE IN LICENSE",
+	"license": "SEE LICENSE IN LICENSE.md",
 	"icon": "assets/logo.png",
 	"galleryBanner": {
 		"color": "#100f11",


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `74296e4`
- New: `staging@ce948109380e`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.

> [!WARNING]
> Registry metadata still claims a different license than the fleet
> LICENSE.md this update delivers. Registries publish the manifest's
> claim, so fix these on this branch or right after merging:

- `package.json`: `"license": "SEE LICENSE IN LICENSE"` - set it to `"SEE LICENSE IN LICENSE.md"`

> [!WARNING]
> This update DELETES LICENSE. Copier
> resolves delete-vs-modify by dropping the file, so content below its
> local-section marker (prior-license notices) is not in this diff -
> recover it from the base branch or git history and port it below
> LICENSE.md's marker on this branch before merging.

> [!WARNING]
> copier hit merge conflicts, resolved below in favor of the
> template where possible. Restore any dropped local lines that
> should stay, and hand-edit anything marked unresolved, before
> merging.

#### `.gitattributes`

Conflict 1: local lines moved below the repository-specific marker (template side kept in place):

````
*.vsix binary
````