### PR TITLE
chore: update repo-platform template to staging@884d384b848c

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: ce94810
+_commit: 884d384
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 copyright_holder: Vivswan Shah (https://github.com/Vivswan)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ local edits to managed files are replaced on the next template sync.
   versioned from these subjects.
 - By opening a pull request, or offering code in an issue or review for
   inclusion, you agree to the Contributions section of the
-  [LICENSE](LICENSE.md), which licenses that code to the licensor -
+  [LICENSE.md](LICENSE.md), which licenses that code to the licensor -
   including for relicensing under any terms - unless you conspicuously
   say otherwise when you submit it.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,25 +1,32 @@
 # Individual and Small Organization License 1.0.0
 
-<https://github.com/Vivswan/repo-platform/blob/main/LICENSE.md>
+<https://github.com/Vivswan/licenses/blob/main/individual-small-organization-license/1.0.0.md>
 
 Required Notice: Copyright Vivswan Shah (https://github.com/Vivswan)
 
 ## Summary (non-binding)
 
-This table is a plain-language guide only; the terms below govern.
+This table is a plain-language guide only; the terms below govern. A
+longer non-binding guide with worked examples:
+<https://github.com/Vivswan/licenses/blob/main/individual-small-organization-license/GUIDE-1.0.0.md>
 
 | You are... | Use it | Fork and build on it | Publish your fork | Change its license |
 |---|---|---|---|---|
-| An individual choosing it for yourself - any purpose, including your own freelance or sole-proprietor business and self-chosen use at your job; a company you formed, even one you own alone, is an organization | Yes | Yes | Yes, under this same license | The software: with the licensor's written permission, plus the agreement of any fork author whose changes that permission does not already cover. Your own additions: always your copyright - under any terms you choose when they contain none of the software's expression and are shared apart from it; as part of the fork, they carry this same license |
-| An organization with fewer than 250 people and under 10,000,000 USD (2026, inflation-adjusted) in total yearly income of every kind - revenue, receipts, contributions, grants, and appropriations included - affiliates counted | Yes, internally only - no client deliverables, and the software and its functionality stay out of anything offered to others (products built with its help are fine); output it generates may be published for its own repositories and systems | No - contact the licensor | No - contact the licensor | No - contact the licensor |
+| An individual choosing it for yourself - any purpose, including self-chosen use at your job (once your organization adopts it for your team, department, or organization, that work use is the organization's and needs the organization's license) and your own freelance, sole-proprietor, or own-company work while your trades and businesses, together with organizations you control, fit the small-organization thresholds below; a company you formed, even one you own alone, is an organization for everything beyond your own work | Yes | Yes | Yes, under this same license | The software: with the licensor's written permission, plus the agreement of any fork author whose changes that permission does not already cover. Your own additions: always your copyright - under any terms you choose when they contain none of the software's expression and are shared apart from it; as part of the fork, they carry this same license |
+| An organization with fewer than 100 people and under 10,000,000 USD (2026, inflation-adjusted) in total yearly income of every kind - revenue, receipts, contributions, grants, and appropriations included - affiliates counted | Yes, internally only - no client deliverables, and the software and its functionality stay out of anything offered to others (products built with its help are fine); output it generates may be published for its own repositories and systems | No - contact the licensor | No - contact the licensor | No - contact the licensor |
 | Any other organization | No - contact the licensor | No - contact the licensor | No - contact the licensor | No - contact the licensor |
 
-An organization paying for, requiring, directing, or provisioning an
-individual's use counts as the organization using it. Service providers
-may host and transmit the software for licensed users (see [Service
-Providers](#service-providers)). To license this software beyond these
-grants, contact the licensor at the address in the Required Notice
-above.
+Except for an individual's own qualifying use in trades, businesses,
+and organizations they control (as the [Individual
+License](#individual-license) provides), an organization paying for,
+requiring,
+directing, or provisioning an
+individual's use - or [adopting](#definitions) the software for a team,
+a department, or the organization - counts as the organization using
+it. Service providers may host and transmit the software for licensed
+users (see [Service Providers](#service-providers)). To license this
+software beyond these grants, contact the licensor at the address in
+the Required Notice above.
 
 ## Acceptance
 
@@ -28,8 +35,9 @@ both strict obligations and conditions to all your licenses. An
 organization can accept these terms only through the sections that
 address organizations: the [Small Organization
 License](#small-organization-license) (by use), [Service
-Providers](#service-providers) (by providing the service), and
-[Contributions](#contributions) (by submitting or authorizing a
+Providers](#service-providers) (by providing the service or doing
+anything that section allows), and [Contributions](#contributions) (by
+submitting or authorizing a
 submission). The output licenses to recipients in the [Individual
 License](#individual-license) and the [Small Organization
 License](#small-organization-license) are granted without acceptance.
@@ -40,21 +48,87 @@ The licensor grants you a copyright license to do everything you might
 do with the software that would otherwise infringe the licensor's
 copyright in it, for any purpose, personal or business, if you are a
 natural person acting in your individual capacity. This includes your
-own freelance and sole-proprietor work, and your own use of the software
-in the course of your employment, provided no organization pays for,
-requires, directs, or provisions that use. Using the software as
-designed is likewise licensed: you may generate, keep, use, and publish
-its output, even where that output carries the software's expression,
-and the [Changes and New Works License](#changes-and-new-works-license)
-and [Distribution License](#distribution-license) sections do not apply
-to output as such. An organization or person that gets output you
-generate under this license may keep, use, and publish it for its own
-repositories and systems, whatever its size; this licenses the output
-only and gives them no license to the software itself. However, you may
-only make changes and new works based on the software according to
-[Changes and New Works License](#changes-and-new-works-license), and
-share the software according to [Distribution
-License](#distribution-license).
+own use of the software in the course of your employment by an
+organization you do not [control](#definitions), provided no
+organization pays for, requires, directs, or provisions that use, and
+the use is not within the scope of an organization's
+[adoption](#definitions) (see [Self-Chosen Use at
+Work](#self-chosen-use-at-work)). It also includes your own work in
+your own trades and businesses - freelance and sole-proprietor work,
+and your own work for organizations you control - provided your trades
+and businesses, measured as the [Definitions](#definitions) provide
+together with every organization you control, would qualify as a
+[small organization](#definitions). While they qualify, your own use
+in them stays licensed by this grant; and, while they qualify, for
+your own use - in them,
+and in your employment above - a payment, requirement, direction, or
+provisioning by those trades, businesses, or organizations, and their
+adopting the software, are disregarded in applying this grant,
+[Self-Chosen Use at Work](#self-chosen-use-at-work), and
+[Organizations](#organizations): those triggers,
+and [adoption](#definitions), reach other people's work for them, and
+a trigger one of them applies, or an adoption one of them makes, at an
+outside organization's specific
+direction or requirement, or under an arrangement specifically
+providing for it, counts as that outside organization's own. If they
+stop qualifying, the wind-down in the [Small
+Organization License](#small-organization-license) applies to that
+work the same way, on the same once-in-36-months terms; beyond it,
+that work needs a separate license (see [Separate
+Licenses](#separate-licenses)), while your personal use and your
+employment use licensed above stay licensed. Using the software as
+designed is likewise licensed: you may generate, keep, use, and
+publish its output, even where that output carries the software's
+expression, and the [Changes and New Works
+License](#changes-and-new-works-license) and [Distribution
+License](#distribution-license) sections do not apply to output as
+such. An organization or person that gets output you generate under
+this license may keep, use, and publish it for its own repositories
+and systems, whatever its size; this licenses the output only and
+gives them no license to the software itself. The output licenses in
+these terms cover only rights the licensor is entitled to license:
+rights of others in material appearing in output are not licensed
+here. However, you may only make changes and new works based on the
+software according to [Changes and New Works
+License](#changes-and-new-works-license), and share the software
+according to [Distribution License](#distribution-license).
+
+## Self-Chosen Use at Work
+
+Your use of the software in the course of your employment or other
+work for an organization remains use in your individual capacity
+unless an organization pays for, requires, directs, or provisions that
+use, or the use is within the scope of an organization's
+[adoption](#definitions). While an organization's adoption continues,
+use within its scope is the organization's - not licensed by the
+[Individual License](#individual-license) - even where you would also
+have chosen the software yourself. Your own work for an organization
+you [control](#definitions) is not employment under this section: the
+[Individual License](#individual-license)'s trades-and-businesses
+clause governs it.
+
+If, however, your use would remain use in your individual capacity
+under the first sentence of this section but for any adoptions whose
+scope covers it, and you do not know that an adoption's scope covers
+that use - whether your use began before or after the adoption - your
+use remains your own and stays licensed under the [Individual
+License](#individual-license) until you know that an adoption's scope
+covers your use, and for 30 days after that, so you can stop using
+the software or the organization can obtain or already hold a license
+covering it. Use in that period is licensed and is not a violation of
+these terms. This grace licenses only your use, not the organization's
+adoption or use, and you can rely on it only once for any one
+adoption.
+
+None of the circumstances the [adoption](#definitions) definition
+excludes - knowledge of or permission for an individual's
+independently chosen use, a recorded clearance for it that stops
+short of presenting the software as a unit's standard, preferred, or
+expected tool, received work product, output, or other incidental
+benefit, or colleagues sharing their own self-chosen setups - is, by
+itself, adoption or makes an organization count as using the software;
+they do not override the preceding rules for a use an organization
+pays for, requires, directs, or provisions.
 
 ## Small Organization License
 
@@ -82,7 +156,9 @@ Products and services the organization builds and offers that contain
 none of the software's expression are its own. An organization or person
 that gets output generated under this section may keep, use, and publish
 it for its own repositories and systems; this licenses the output only
-and gives them no license to the software itself.
+and gives them no license to the software itself, and it covers only
+rights the licensor is entitled to license, as in the [Individual
+License](#individual-license).
 
 An organization accepts these terms by using the software, and each use
 is also its representation that it qualifies as a small organization or
@@ -140,8 +216,13 @@ mirror, package registry, or network - to host, store, cache, transmit,
 and copy the software as needed to serve anyone exercising these
 licenses, whether at the direction of someone exercising them or on the
 provider's own initiative for copies that the licensor, or someone
-exercising these licenses, made available. This section grants no other
-organizational use.
+exercising these licenses, made available. These terms likewise allow
+an organization to copy, install, enable, and configure the software
+as needed to carry out an individual's own request for their
+individually licensed use, or to apply generally applicable security
+or compliance configuration to software an individual independently
+chose for their individually licensed use. This section grants no
+other organizational use.
 
 ## Your Own Work
 
@@ -161,6 +242,16 @@ relicense - including contributions received under
 any other author whose changes that permission does not cover. Ask via
 the address in the Required Notice.
 
+## Separate Licenses
+
+The licensor may offer the software under other terms, including
+commercial terms. If you accept a separate written license from the
+licensor covering the software or a particular use of it, that separate
+license governs that software or use to the extent it says it does;
+these terms continue to govern whatever it does not cover, and a
+separate license you do not accept does not reduce your licenses under
+these terms.
+
 ## Contributions
 
 By submitting a change or new work to one of the licensor's repositories
@@ -179,6 +270,10 @@ infringes, alone or as part of the software or any other work, to make,
 have made, use, offer to sell, sell, and import it - a patent license
 that extends to everyone who receives the contribution, or anything
 containing it, from the licensor or under terms the licensor grants.
+To the extent the law allows, you waive, and agree not to assert
+against the licensor or anyone exercising rights the licensor grants,
+any moral rights in the contribution; where the law does not allow
+waiver, you consent to every exercise of the rights granted here.
 Material you conspicuously identify, when you submit it, as someone
 else's work, naming its source and, where you know them, its license
 terms, is not a contribution under this section: it stays under its own
@@ -199,11 +294,23 @@ right under these terms to use, deploy, integrate, distribute, or
 operate the software or anything built on it, as part of its systems,
 products, services, or operations, regardless of the organization's
 purpose or funding; no individual's licenses extend to use an
-organization pays for, requires, directs, or provisions; and an
+organization pays for, requires, directs, or provisions, or to use
+within the scope of an organization's [adoption](#definitions), except
+as the [Individual License](#individual-license) provides for your own
+use in trades, businesses, and organizations you
+[control](#definitions) and as [Self-Chosen Use at
+Work](#self-chosen-use-at-work) provides during its grace; and,
+subject to the Individual License exception, an
 organization that pays for, requires, directs, or provisions any use -
-an individual's or another organization's - counts as using the software
-itself. An organization that wants more must get a separate license:
-contact the licensor at the address in the Required Notice.
+an individual's or another organization's - or that adopts the
+software, counts as using the software itself, whether or not the
+organization itself copies it. Many individual licenses are no
+substitute for an organizational one: coordinating separate
+individuals' use of the software into a recurring practice for a team,
+a department, or the organization is adoption (see
+[Definitions](#definitions)). An organization that wants more must get
+a [separate license](#separate-licenses): contact the licensor at the
+address in the Required Notice.
 
 ## Notices
 
@@ -257,7 +364,20 @@ and you received no such notice in the preceding 36 months, your
 licenses can nonetheless continue if you come into full compliance with
 these terms, and take practical steps to correct past violations, within
 32 days of receiving notice. Otherwise, all your licenses end
-immediately.
+immediately. A notice counts under this section only as to conduct
+these terms do not license. To the extent a notice concerns use that
+these terms license - including use licensed by the grace in
+[Self-Chosen Use at Work](#self-chosen-use-at-work) or the wind-down
+in the [Small Organization License](#small-organization-license) - it
+is not such a notice and does not count toward that 36-month period.
+
+## If a Term Fails
+
+If any of these terms is unenforceable as written, it applies to the
+greatest extent the law allows, and the rest of these terms continue
+unchanged. The licensor's not enforcing a term, against
+you or anyone else, waives nothing: every term stays enforceable
+against everyone, for every later violation.
 
 ## No Liability
 
@@ -271,7 +391,11 @@ software, under any kind of legal claim.***
 The **licensor** is the individual or entity offering these terms,
 including any successor to or assignee of the copyrights in the
 software, and the **software** is the software the licensor makes
-available under these terms.
+available under these terms, excluding material the licensor clearly
+identifies - or a submitter identifies as [Contributions](#contributions)
+provides - as excluded from these terms and governed instead by its
+own terms: that material stays under its own terms, and
+these terms do not replace them.
 
 **You** refers to a natural person agreeing to these terms, acting in
 their individual capacity, or an organization agreeing to these terms as
@@ -282,12 +406,15 @@ each "you" receives is set by the license sections themselves.
 
 An **organization** is any legal entity or group - corporation, company,
 partnership, nonprofit, charity, educational institution, government
-body, or otherwise - other than a natural person acting alone. A **small
+body, or otherwise - other than a natural person acting alone; a
+natural person's trade or business in which anyone besides that person
+personally performs work is such a group. A **small
 organization** is an organization that, counted together with every
 organization that controls it, is controlled by it, or is under common
-control with it (together, its **group**), has fewer than 250 total
-individuals working for those organizations combined - as employees,
-independent contractors, or through staffing or outsourcing arrangements -
+control with it (together, its **group**), has fewer than 100 distinct
+natural persons personally performing work for those organizations
+combined - whether as employees, independent contractors, or personnel
+assigned through staffing or outsourcing arrangements -
 and less than 10,000,000 USD in those organizations' combined total
 revenue, receipts, contributions, grants, appropriations, and other
 income, excluding amounts any of those organizations receives from
@@ -305,7 +432,20 @@ it has no prior tax year, for the most recent calendar year ended before
 the use, using the United States Bureau of Labor Statistics' consumer
 price index for all urban consumers (CPI-U), U.S. city average, all
 items, or its successor index; until that bureau publishes the 2026
-annual average, the threshold applies unadjusted. **Control** means
+annual average, the threshold applies unadjusted. When these terms
+measure an individual's own **trades and businesses**, they are counted
+as if they were one organization, with every organization the
+individual controls in its group, and leaving out wages, salary, and
+other compensation the individual earns as an employee. That deemed
+organization uses the individual's tax year; it has a prior tax year
+only if at least one of the individual's trades or businesses,
+including any since ended, operated during it,
+and is otherwise treated as formed when the earliest of the current
+ones began; and it keeps one identity for the once-in-36-months
+wind-down rule however trades and businesses start, end, or
+reorganize, sharing wind-down history with every organization in its
+group; wind-downs arising from the same disqualifying event count as
+one reliance, sharing one 90-day period. **Control** means
 ownership of substantially all the assets of an entity, ownership,
 direct or indirect, of a majority economic or beneficial interest in it,
 or the power to direct its management and policies by vote, contract, or
@@ -314,11 +454,30 @@ arise solely from customary protective, veto, or negative-covenant
 rights held by minority investors or lenders, or from ordinary customer,
 supplier, services, or franchise contracts, unless they confer the
 affirmative power to direct the entity's management and policies
-generally. An organization **provisions** a use when it supplies or
+generally. A natural person controls that person's own trades and
+businesses. For the [Individual License](#individual-license),
+[Self-Chosen Use at Work](#self-chosen-use-at-work), and the
+exceptions built on them - including how an individual's trades and
+businesses are measured - control you hold only jointly counts as
+control only when the distinct natural persons who ultimately share
+that
+control - you included, looking through every organization holding any
+of it - number no more than five; otherwise, for those sections and
+exceptions, you are treated as not controlling the organization whose
+control is being determined. An
+organization
+**provisions** a use when it supplies or
 arranges the software for that use - procuring, installing, deploying,
 or configuring the software, or an account or license for it; providing
 general-purpose equipment, network access, or a development environment
-not specific to the software is not provisioning. An organization **pays
+not specific to the software is not provisioning, nor is carrying out
+an individual's own request to install, enable, or configure software
+that individual chose, through generally available IT support or
+self-service processes, when the organization does not otherwise pay
+for, require, or direct the use, and the use is not within the scope of
+an adoption; applying generally applicable security or compliance
+configuration to software an individual independently chose is, on the
+same conditions, likewise not provisioning. An organization **pays
 for** a use when it pays for the software or for that use specifically -
 a copy, license, subscription, support, or hosting or compute procured
 to run the software, or payment or reimbursement tied to obtaining or
@@ -330,6 +489,40 @@ this software specifically a condition, instruction, or assigned means
 of the work; permitting or tolerating a use someone else chooses is
 neither.
 
+An organization **adopts** the software for a team, a department, or
+the organization (the **unit**) when it takes action intended to
+establish the software as a tool for recurring use by that unit - for
+example, by standardizing on it, designating or recommending it as a
+standard, preferred, or expected tool for that unit, assigning or
+instructing people in that unit to use it, deploying it centrally for
+that unit, integrating it into shared or automated infrastructure that
+unit uses, providing or endorsing internal documentation, shared
+accounts, or shared configuration for that unit's use, or coordinating
+separate individuals' use of the software into a recurring practice
+for that unit.
+
+An organization takes such an action only when the action is taken by
+someone with authority to set tools for the unit, is taken at the
+organization's direction, or is known to someone with that authority -
+or would be, but for such a person's deliberate avoidance of that
+knowledge - and
+allowed, in fact, to stand as the unit's practice. The scope of an
+adoption is use in the course of work for the unit the action
+addresses. An adoption ends when the
+organization withdraws or discontinues, as applicable, the actions
+that established it and no longer maintains or gives effect to them,
+so that the software is no longer established as a tool for the unit's
+recurring use; a later action can establish a new adoption.
+
+None of the following is adoption: knowing of or permitting an
+individual's independently chosen use; recording a security, legal, or
+compliance clearance for individually chosen use - including on a list
+of cleared or permitted software - without presenting the software as
+a unit's standard, preferred, or expected tool; receiving work
+product, output, or other incidental benefit from a use; or
+individuals sharing notes, documentation, or configuration about their
+own independently chosen use with colleagues.
+
 **Your licenses** are all the licenses granted to you for the software
 under these terms.
 
@@ -340,7 +533,7 @@ expression.
 **Use** means anything you do with the software requiring one of your
 licenses.
 
-<!-- Repository-specific license notices (licensing of earlier versions,
-     third-party components, differently licensed paths) go below this
-     line. They survive template updates via three-way merge. -->
+<!-- Repository-specific license notices (third-party components,
+     differently licensed paths) go below this line. They survive
+     template updates via three-way merge. -->
 <!-- repo-platform:local-section -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,10 @@ Only the latest release is supported.
 
 Report vulnerabilities privately via
 [GitHub Security Advisories](https://github.com/vivswan/litellm-vscode-chat/security/advisories/new)
-("Report a vulnerability"). A useful report includes:
+("Report a vulnerability"). If that page is unavailable (GitHub offers no
+advisories on private personal repositories), contact
+[@Vivswan](https://github.com/vivswan)
+directly instead. A useful report includes:
 
 - what an attacker can do (impact), and where trust is broken,
 - reproduction steps or a proof of concept,


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `ce94810`
- New: `staging@884d384b848c`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.