### PR TITLE
chore: update repo-platform template to staging@4a330111abe6

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # This file is managed by Vivswan/repo-platform.
 # Copier uses it to track the template source and version - do not delete.
-_commit: 97ffa5b
+_commit: 4a33011
 _src_path: gh:Vivswan/repo-platform
 channel: staging
 copyright_holder: Vivswan Shah (https://github.com/Vivswan)
@@ -16,7 +16,9 @@ modules:
 - pr-title
 - auto-assign
 - fuzzer
+- nightly
 - settings-sync
+nightly_label: nightly-failure
 private: false
 project_name: LiteLLM VSCode Chat
 project_slug: litellm-vscode-chat

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -80,6 +80,13 @@ labels:
   - name: "nightly-fuzz"
     color: "B60205"
     description: Automated nightly fuzz failure
+  # The nightly-CI tracking label (nightly module): the fuzz-issue action
+  # keys its one-open-issue-per-label dedup on it, so it must survive the
+  # label sync. Values match the tuple the nightly starter passes to the
+  # action for label creation.
+  - name: "nightly-failure"
+    color: "D93F0B"
+    description: Automated nightly CI failure
 
 
 # Branch ruleset for the default branch. Admins (RepositoryRole id 5) are in

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -21,7 +21,7 @@ on:
     workflows: ["CI"]
     types: [completed]
   schedule:
-    - cron: "23 6 * * 1"
+    - cron: "13 6 * * 1"
 
 # No workflow-level grants: each job below grants its reusable workflow
 # exactly what that capability needs. contents:read is CODEOWNERS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ on:
   # Weekly CodeQL re-scan with refreshed query packs; every other gate job
   # is event-agnostic or skips its work cleanly on non-PR events.
   schedule:
-    - cron: "23 4 * * 1"
+    - cron: "3 8 * * 1"
 
 permissions:
   contents: read
@@ -179,12 +179,12 @@ jobs:
           fi
 
   # Early, visible release gating: fails the release PR while an open issue
-  # carries the fuzz-tracking or release-blocker label, or an open Dependabot
-  # alert reaches the severity threshold. This check can go stale (an issue
-  # opened after the PR turned green re-runs nothing here), so the release
-  # path re-runs the same action as the authoritative pre-flight before
-  # cutting a release. The skip lives on the STEP: all-green treats a
-  # skipped needed job as failure.
+  # carries a tracking-stream label (nightly fuzz/CI) or the release-blocker
+  # label, or an open Dependabot alert reaches the severity threshold. This
+  # check can go stale (an issue opened after the PR turned green re-runs
+  # nothing here), so the release path re-runs the same action as the
+  # authoritative pre-flight before cutting a release. The skip lives on
+  # the STEP: all-green treats a skipped needed job as failure.
   release-health:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -202,7 +202,7 @@ jobs:
         if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--')
         with:
           mode: pull-request
-          fuzz-label: "nightly-fuzz"
+          tracking-labels: "nightly-fuzz,nightly-failure"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,95 @@
+# Nightly CI starter. Generated once by Vivswan/repo-platform
+# and never overwritten by template sync, so edit freely. Replace the
+# placeholder step with this repository's own nightly checks (the suites too
+# slow for every PR: full end-to-end runs, docker image builds, live
+# integration tests); the report job below keeps working unchanged - a red
+# night files or updates one label-deduplicated tracking issue, a green
+# night closes it (see repo-platform's docs/nightly.md).
+name: Nightly
+
+on:
+  schedule:
+    # Overnight US-Eastern, off the top of the hour, and offset from the
+    # fuzzer starter; pick your repo's own minute so the fleet's nightlies
+    # do not all land on GitHub at once.
+    - cron: "59 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+# The checks job needs only the checkout; the report job scopes its own
+# issue and dispatch permissions below.
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      # Set up whatever the nightly checks need here (toolchains, docker,
+      # service containers, caches, ...). Add sibling jobs freely: list
+      # every one in the report job's `needs` and fold its result into the
+      # red/green conditions there.
+
+      - name: Nightly checks
+        run: |
+          # Replace this placeholder with the repository's nightly checks.
+          # Any failing step in this job makes the report job below file
+          # or update the tracking issue. Until then this step is a green
+          # no-op on purpose: an uncustomized starter must not file issues.
+          echo "::warning::nightly starter not customized yet - replace the placeholder step (see repo-platform's docs/nightly.md)"
+
+  # Runs whatever happened to the checks job, and treats a CANCELLED checks
+  # job as red: a job that hits its timeout is cancelled, not failed, and a
+  # hang is exactly what a nightly run exists to catch.
+  report:
+    needs: [checks]
+    if: always()
+    runs-on: ubuntu-latest
+    # A few gh calls behind a bun setup; a hung reporter is the residual
+    # silence window, so keep this tight.
+    timeout-minutes: 5
+    # issues: write lets the fuzz-issue action file/close the tracking issue;
+    # actions: write lets the red path dispatch auto-assign at it.
+    permissions:
+      issues: write
+      actions: write
+    steps:
+      - name: File or update the nightly issue
+        id: file-issue
+        if: needs.checks.result == 'failure' || needs.checks.result == 'cancelled'
+        uses: Vivswan/repo-platform/actions/fuzz-issue@main
+        with:
+          mode: report
+          label: "nightly-failure"
+          title: Nightly CI failures
+          # No artifacts directory is passed: this stream files the generic
+          # nightly-failure report (workflow, commit, run link) rather than
+          # the fuzzer's failure-report contract. The tuple below is used
+          # only when the label has to be created and matches the
+          # settings-sync declaration.
+          label-color: "D93F0B"
+          label-description: Automated nightly CI failure
+
+      # A GITHUB_TOKEN-created issue fires no triggers, so dispatch auto-assign.
+      - name: Trigger auto-assign for the filed issue
+        if: steps.file-issue.outputs.issue-number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.file-issue.outputs.issue-number }}
+        run: gh workflow run auto-assign.yml -f "issue=$ISSUE_NUMBER" || echo "::warning::could not dispatch auto-assign.yml"
+
+      - name: Close the nightly issue on a green night
+        if: needs.checks.result == 'success'
+        uses: Vivswan/repo-platform/actions/fuzz-issue@main
+        with:
+          mode: resolve
+          label: "nightly-failure"
+          # The generic close wording; without it the action keeps the fuzz
+          # stream's regression-seed hedging.
+          stream: generic

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,7 +63,7 @@ jobs:
           fi
       # Authoritative release gating: the release PR's release-health CI job
       # gives early visible feedback, but it can be stale by merge time (a
-      # fuzz or blocker issue opened after that PR went green re-runs no
+      # tracking or blocker issue opened after that PR went green re-runs no
       # check), so the same action runs again here before release-please
       # acts. In release mode the gate self-scopes to release-cut pushes:
       # it gates only a push that merges a release-please-- PR (reading the
@@ -74,7 +74,7 @@ jobs:
         if: steps.head.outputs.current == 'true'
         with:
           mode: release
-          fuzz-label: "nightly-fuzz"
+          tracking-labels: "nightly-fuzz,nightly-failure"
         env:
           GH_TOKEN: ${{ github.token }}
       - uses: googleapis/release-please-action@v5


### PR DESCRIPTION
Automated template update from [`Vivswan/repo-platform`](https://github.com/Vivswan/repo-platform/tree/staging) (staging channel).

- Previous: `97ffa5b`
- New: `staging@4a330111abe6`

Review any merge conflicts and confirm repository-local sections were preserved before merging.

> [!NOTE]
> This branch is regenerated on every sync run; manual commits
> pushed to it are overwritten. Make fixes in a separate branch or
> after merging.