### PR TITLE
test: pin the raw 0/0 free-pricing boundary the fuzz property misread (#282)

### DIFF
--- a/src/test/provider/index.test.ts
+++ b/src/test/provider/index.test.ts
@@ -1050,6 +1050,38 @@ suite("provider", () => {
 			assert.ok(!("priceCategory" in dust), "nor earn a low-cost badge");
 		});
 
+		test("a raw 0/0 pair prices as genuinely free (nightly seed 124443 counterexample, #282)", () => {
+			// The boundary the dust rule must not swallow: a RAW zero pair at this
+			// layer can only be user-written free (discovery maps the server's 0/0
+			// no-pricing stamp to undefined before registration), so it keeps the
+			// free label and the low badge - the zeroPair carve-out in
+			// pricingFromCosts.
+			const { infos } = buildModelInfos(
+				[
+					{
+						id: "free",
+						shape: {
+							kind: "deployment",
+							provider: {
+								provider: "openai",
+								status: "ok",
+								input_cost_per_token: 0,
+								output_cost_per_token: 0,
+							},
+						},
+					},
+				],
+				{ id: "srv1", label: "Default", baseUrl: TEST_BASE_URL, apiKey: "k" },
+				1,
+				() => {}
+			);
+			const free = expectDefined(infos[0]);
+			assert.strictEqual(free.inputCost, 0);
+			assert.strictEqual(free.outputCost, 0);
+			assert.strictEqual(free.priceCategory, "low", "genuinely free keeps the low-cost badge");
+			assert.strictEqual(free.pricing, "$0 in / $0 out per 1M tokens", "and the free display label");
+		});
+
 		test("priceCategory is always one of the four literals the host renders", () => {
 			// The host renders any other string through a capitalized "<Foo> cost"
 			// fallback, so the derivation may only ever emit the known four.
@@ -1083,6 +1115,15 @@ suite("provider", () => {
 					if (info.inputCost !== undefined && info.outputCost !== undefined) {
 						if (info.inputCost > 0 || info.outputCost > 0) {
 							assert.ok(info.priceCategory !== undefined, "a nonzero two-sided price always derives a category");
+						} else if (inputPerToken === 0 && outputPerToken === 0) {
+							// The RAW zero pair at this layer can only be user-written
+							// "genuinely free": discovery's serverCostsOf maps the
+							// server's 0/0 no-pricing stamp to undefined before any shape
+							// reaches registration, so the zeroPair carve-out keeps the
+							// free label and badge on purpose. Nightly seed 124443 caught
+							// the previous oracle asserting the opposite here (#282).
+							assert.strictEqual(info.priceCategory, "low", "a raw 0/0 pair prices as genuinely free");
+							assert.ok(info.pricing !== undefined, "and carries the free display label");
 						} else {
 							// Both sides rounded to 0: sub-unit dust that slipped the raw
 							// 0/0 undeclared check must not present the model as free.


### PR DESCRIPTION
## The failure this pins (#282)

Nightly fuzz, seed 124443, minimal counterexample `[0, 0]`:

```text
Property failed after 76 tests
Counterexample: [0,0]
AssertionError: a rounded-0/0 pair derives no category
```

## How

```text
verdict: the PRODUCT is correct - the property's oracle misread a boundary
server 0/0 pair -> discovery serverCostsOf -> undefined (no-pricing stamp)   [never reaches registration]
raw 0/0 at registration -> only user-written "genuinely free" -> keeps label + low badge (zeroPair carve-out)
dust (rounds to 0/0)   -> no label, no badge                                  [unchanged]
```

Test-only change: the property gains the raw-0/0 branch asserting the carve-out, and the counterexample is pinned as an example test beside the existing dust example.

## Proof

- `FUZZ_SEED=124443 FUZZ_RUNS=1000` replay green (2665 passing)
- Codex review round: "Correct. No BLOCKING or NON-BLOCKING findings." (verified all three ingest paths sanitize server 0/0)

Fixes #282
