### PR TITLE
chore: drop the retired REPOSITORY LOCAL relic lines from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-
-# BEGIN REPOSITORY LOCAL
-# Add repository-specific ignore patterns in this section only.
-
 # Agent configs: only the checked-in settings/hooks files are tracked
 .claude/*
 !.claude/settings.json
@@ -64,8 +60,6 @@ docker/.copilot-token/*
 # Agent scratch probes (throwaway measurement fixtures/scripts); cleaned up
 # after use, ignored so a forgotten one can never land in a commit
 .probe*
-
-# END REPOSITORY LOCAL
 
 # BEGIN REPO-PLATFORM MANAGED
 # Generated from github/gitignore - do not edit between the BEGIN/END


### PR DESCRIPTION
## What this removes

Three platform-authored lines, matched by exact trimmed-string equality:

```text
# BEGIN REPOSITORY LOCAL
# Add repository-specific ignore patterns in this section only.
# END REPOSITORY LOCAL
```

## Before / After

```diff
diff --git a/.gitignore b/.gitignore
index 3a6230c..2d4f38a 100644
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-
-# BEGIN REPOSITORY LOCAL
-# Add repository-specific ignore patterns in this section only.
-
 # Agent configs: only the checked-in settings/hooks files are tracked
 .claude/*
 !.claude/settings.json
@@ -65,8 +61,6 @@ docker/.copilot-token/*
 # after use, ignored so a forgotten one can never land in a commit
 .probe*
 
-# END REPOSITORY LOCAL
-
 # BEGIN REPO-PLATFORM MANAGED
 # Generated from github/gitignore - do not edit between the BEGIN/END
 # markers; repository-local patterns live outside the managed region
```

## Why

The `.gitignore` grammar conversion preserved this repo's owned bytes exactly, so these three lines rode along into the repo-owned half above `# BEGIN REPO-PLATFORM MANAGED` as relics of the retired shape - and their guidance is now false, since repository-local patterns may live either above BEGIN or below END (where last-match-wins can override), not "in this section only".

## Proof

- Deletions only: the three quoted lines plus the blank-line residue they left (no leading blank at the top of the file, no doubled blank at the seam). The diff adds zero bytes.
- No pattern line is touched, so the ignore semantics are byte-for-byte identical; only comments and blanks moved.
- The pre-existing blank-line separator inside the managed region is left alone.
