### PR TITLE
ci: post the sticky PR comments through marocchino/sticky-pull-request-comment

### DIFF
--- a/.github/workflows/dependabot-vscode-floor.yml
+++ b/.github/workflows/dependabot-vscode-floor.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
-      pull-requests: write # the no-retrigger-token PR comment below
+      pull-requests: write # the no-retrigger-token sticky comment below
     steps:
       - uses: actions/checkout@v7
         with:
@@ -47,13 +47,12 @@ jobs:
       - name: Raise engines.vscode and the doc floors to the @types/vscode pin
         run: bun scripts/ci/sync-vscode-floor.ts
       - name: Commit and push the floor bump
+        id: push
         shell: bash
         env:
           TOKEN: ${{ secrets.REPO_PLATFORM_TOKEN || github.token }}
           CAN_RETRIGGER: ${{ secrets.REPO_PLATFORM_TOKEN != '' }}
-          GH_TOKEN: ${{ github.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if git diff --quiet; then
             echo "floor already in sync"
@@ -85,14 +84,17 @@ jobs:
           if [ "$CAN_RETRIGGER" = "true" ]; then
             exit 0
           fi
-          # github.token starts no workflows: say so on the PR (once) and
-          # as an annotation, but stay green - the fleet legitimately runs
-          # without the token.
-          marker="<!-- dependabot-vscode-floor: no-retrigger-token -->"
-          comments=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq '.[].body' || true)
-          case "$comments" in
-            *"$marker"*) ;;
-            *) gh pr comment "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --body "$marker
-          Pushed an engines.vscode floor bump with the default workflow token, which starts no workflows, so checks will not re-run on the new head. Close and reopen this PR to re-run them, or register \`REPO_PLATFORM_TOKEN\` as a Dependabot secret so future fixes re-trigger CI automatically." || true ;;
-          esac
+          # github.token starts no workflows: say so on the PR (the sticky
+          # comment below) and as an annotation, but stay green - the fleet
+          # legitimately runs without the token.
+          echo "no_retrigger=true" >> "$GITHUB_OUTPUT"
           echo "::warning::floor bump pushed without REPO_PLATFORM_TOKEN - checks will not re-run on the new head; close/reopen the PR or register the token as a Dependabot secret"
+      # One comment per PR, edited in place on every fix push; a posting
+      # failure fails the step.
+      - name: Say the fix push cannot re-trigger CI
+        if: steps.push.outputs.no_retrigger == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: dependabot-vscode-floor
+          message: |
+            Pushed an engines.vscode floor bump with the default workflow token, which starts no workflows, so checks will not re-run on the new head. Close and reopen this PR to re-run them, or register `REPO_PLATFORM_TOKEN` as a Dependabot secret so future fixes re-trigger CI automatically.

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -57,7 +57,17 @@ jobs:
       # bun smoke test runs the executable the same bare way.
       - name: Render the migration-expiry table
         id: render
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
+          # The sticky-comment action reads a missing or unparseable PR number
+          # as nothing to do and exits green; refuse one before it can.
+          case "$PR_NUMBER" in
+            ''|0*|*[!0-9]*)
+              echo "::error::pr_number must be a positive integer, got '$PR_NUMBER'"
+              exit 1
+              ;;
+          esac
           bun --no-install scripts/ci/migration-expiry-table.ts > "$RUNNER_TEMP/migration-expiries.md"
           # An empty rendering means no migration is live: the step below
           # then deletes the comment instead of posting an empty table.
@@ -73,9 +83,21 @@ jobs:
       # the event payload names no pull request: number carries the release
       # PR's.
       - name: Post, update, or delete the sticky comment
+        id: sticky
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: migration-expiries
           number: ${{ inputs.pr_number }}
           path: ${{ runner.temp }}/migration-expiries.md
           delete: ${{ steps.render.outputs.empty }}
+
+      # A live table that reached no comment is the one silent outcome the
+      # action can still produce (it skips instead of failing when its lookup
+      # has nothing to work on); it fails here instead.
+      - name: Fail if a live table reached no comment
+        if: steps.render.outputs.empty == 'false' && steps.sticky.outputs.previous_comment_id == '' && steps.sticky.outputs.created_comment_id == ''
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          echo "::error::the sticky-comment action neither found nor created a comment on PR $PR_NUMBER"
+          exit 1

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      # Commenting on a PR through the issues endpoints needs pull-requests write.
+      # The sticky-comment action posts, edits, and deletes its PR comment.
       pull-requests: write
     steps:
       # Default ref on purpose: main's registry, not the PR head - the
@@ -56,47 +56,26 @@ jobs:
       # auto-install a package import when node_modules is absent - and the
       # bun smoke test runs the executable the same bare way.
       - name: Render the migration-expiry table
-        run: bun --no-install scripts/ci/migration-expiry-table.ts > "$RUNNER_TEMP/migration-expiries.md"
-
-      - name: Post or update the sticky comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+        id: render
         run: |
-          # The marker is the renderer's first output line
-          # (MIGRATION_EXPIRY_MARKER in scripts/ci/migration-expiry-render.ts;
-          # a bun test pins the two literals together). Matching it on this
-          # workflow's own bot comments only - anyone with write access could
-          # PATCH another user's comment, and a user-posted marker must not
-          # draw an edit - keeps the update idempotent: one comment, edited in
-          # place, stray duplicates healed by deletion.
-          ids="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
-            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- migration-expiries -->")) | .id')"
-          first=""
-          extras=()
-          while IFS= read -r id; do
-            if [ -z "$id" ]; then
-              continue
-            fi
-            if [ -z "$first" ]; then
-              first="$id"
-            else
-              extras+=("$id")
-            fi
-          done <<< "$ids"
-          # The primary update runs before duplicate healing so a DELETE
-          # hiccup (a 404 from a comment another run already removed) can
-          # never block the table refresh itself.
-          if [ -n "$first" ]; then
-            gh api --method PATCH "repos/$GH_REPO/issues/comments/$first" \
-              -F "body=@$RUNNER_TEMP/migration-expiries.md" > /dev/null
+          bun --no-install scripts/ci/migration-expiry-table.ts > "$RUNNER_TEMP/migration-expiries.md"
+          # An empty rendering means no migration is live: the step below
+          # then deletes the comment instead of posting an empty table.
+          if [ -s "$RUNNER_TEMP/migration-expiries.md" ]; then
+            echo "empty=false" >> "$GITHUB_OUTPUT"
           else
-            gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
-              -F "body=@$RUNNER_TEMP/migration-expiries.md" > /dev/null
+            echo "empty=true" >> "$GITHUB_OUTPUT"
           fi
-          for id in "${extras[@]}"; do
-            echo "deleting duplicate sticky comment $id"
-            gh api --method DELETE "repos/$GH_REPO/issues/comments/$id" > /dev/null \
-              || echo "::warning::could not delete duplicate sticky comment $id"
-          done
+
+      # The action finds its earlier comment by the header (its own hidden
+      # marker) among the token identity's comments, edits it in place, and
+      # deletes it when the registry has drained. The caller runs on push, so
+      # the event payload names no pull request: number carries the release
+      # PR's.
+      - name: Post, update, or delete the sticky comment
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: migration-expiries
+          number: ${{ inputs.pr_number }}
+          path: ${{ runner.temp }}/migration-expiries.md
+          delete: ${{ steps.render.outputs.empty }}

--- a/scripts/ci/migration-expiry-render.ts
+++ b/scripts/ci/migration-expiry-render.ts
@@ -1,18 +1,12 @@
 /**
  * Pure renderer for the migration-expiry sticky comment posted on the
  * release-please release PR (.github/workflows/update-release-pr.yml).
- * The executable wrapper is migration-expiry-table.ts.
+ * The executable wrapper is migration-expiry-table.ts. The comment's
+ * identity is the sticky-comment action's header, not anything in this
+ * body: the body carries only what a reader sees.
  */
 
 import type { MigrationExpiry } from "../../src/extension/migrations/expiries";
-
-/**
- * First line of the rendered document and the sticky-comment identity: the
- * release-PR workflow finds its earlier comment by this exact prefix, so this
- * literal and the jq filter in update-release-pr.yml move together (a bun
- * test pins them).
- */
-export const MIGRATION_EXPIRY_MARKER = "<!-- migration-expiries -->";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -26,10 +20,16 @@ function daysRemaining(expires: string, today: Date): number {
 	return Math.round((Date.parse(expires) - Date.parse(today.toISOString().slice(0, 10))) / DAY_MS);
 }
 
-/** The full markdown document for the sticky comment, marker line first. */
+/**
+ * The full markdown document for the sticky comment, or the empty string
+ * when no migration is live: the workflow reads an empty rendering as "delete
+ * the comment", so a release PR carries no table once the registry drains.
+ */
 export function renderMigrationExpiryTable(expiries: readonly MigrationExpiry[], today: Date): string {
+	if (expiries.length === 0) {
+		return "";
+	}
 	const lines = [
-		MIGRATION_EXPIRY_MARKER,
 		"Expired migrations fail the build; delete the migration and move its storage keys into the activation cleanup.",
 		"",
 		"| Migration | Introduced | Expires | Days remaining |",

--- a/scripts/ci/migration-expiry-table.ts
+++ b/scripts/ci/migration-expiry-table.ts
@@ -1,10 +1,12 @@
 /**
  * Prints the migration-expiry sticky comment for the release PR to stdout:
- * every MIGRATION_EXPIRIES row with its days remaining as of today.
- * .github/workflows/update-release-pr.yml renders this and posts/updates the
- * comment. The registry is a zero-import leaf, so this script's whole runtime
- * graph is dependency-free and runs without node_modules; a bun smoke test
- * runs this executable so a break lands on the PR that introduced it.
+ * every MIGRATION_EXPIRIES row with its days remaining as of today, or
+ * nothing at all when the registry is empty (the workflow then deletes the
+ * comment). .github/workflows/update-release-pr.yml renders this and hands
+ * the file to the sticky-comment action. The registry is a zero-import leaf,
+ * so this script's whole runtime graph is dependency-free and runs without
+ * node_modules; a bun smoke test runs this executable so a break lands on the
+ * PR that introduced it.
  */
 
 import { MIGRATION_EXPIRIES } from "../../src/extension/migrations/expiries";

--- a/src/test/bun/scripts/ci/migration-expiry-render.test.ts
+++ b/src/test/bun/scripts/ci/migration-expiry-render.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { MIGRATION_EXPIRY_MARKER, renderMigrationExpiryTable } from "../../../../../scripts/ci/migration-expiry-render";
+import { renderMigrationExpiryTable } from "../../../../../scripts/ci/migration-expiry-render";
+import { MIGRATION_EXPIRIES } from "../../../../extension/migrations/expiries";
 import type { MigrationExpiry } from "../../../../extension/migrations/index";
 import { REPO_ROOT } from "../../../util/repoRoot";
 import { CHILD_PROCESS_TIMEOUT_MS } from "../../childProcessTimeout";
@@ -17,11 +18,10 @@ const ENTRIES: readonly MigrationExpiry[] = [
 ];
 
 describe("renderMigrationExpiryTable", () => {
-	test("renders the marker first, the header note, and one row per entry with signed days remaining", () => {
+	test("renders the header note and one row per entry with signed days remaining", () => {
 		const rendered = renderMigrationExpiryTable(ENTRIES, new Date("2026-09-01T12:34:56Z"));
 		expect(rendered).toBe(
 			[
-				MIGRATION_EXPIRY_MARKER,
 				"Expired migrations fail the build; delete the migration and move its storage keys into the activation cleanup.",
 				"",
 				"| Migration | Introduced | Expires | Days remaining |",
@@ -34,11 +34,12 @@ describe("renderMigrationExpiryTable", () => {
 		);
 	});
 
-	test("the marker is the first line, so the release workflow's startswith match finds the comment", () => {
-		expect(MIGRATION_EXPIRY_MARKER).toBe("<!-- migration-expiries -->");
-		expect(
-			renderMigrationExpiryTable([], new Date("2026-09-01T00:00:00Z")).startsWith(`${MIGRATION_EXPIRY_MARKER}\n`)
-		).toBe(true);
+	test("renders nothing for an empty registry, which the release workflow reads as delete the comment", () => {
+		// The workflow tests the rendered file with `-s` and hands `delete: true`
+		// to the sticky-comment action when it is empty; a header note or a
+		// bare table skeleton here would keep an empty table alive on every
+		// release PR instead.
+		expect(renderMigrationExpiryTable([], new Date("2026-09-01T00:00:00Z"))).toBe("");
 	});
 
 	test("days remaining counts UTC calendar dates, indifferent to the time of day", () => {
@@ -48,14 +49,6 @@ describe("renderMigrationExpiryTable", () => {
 			expect(rendered).toContain("| 2026-06-01 | 2026-09-01 | 0 |");
 			expect(rendered).toContain("| 2026-05-30 | 2026-08-30 | -2 |");
 		}
-	});
-
-	test("update-release-pr.yml's jq filter matches this exact marker literal", () => {
-		// The workflow cannot import the constant, so the two literals are pinned
-		// here: change the marker without the jq filter and every release-PR
-		// refresh would POST a fresh comment instead of editing the old one.
-		const workflow = readFileSync(join(REPO_ROOT, ".github", "workflows", "update-release-pr.yml"), "utf8");
-		expect(workflow).toContain(`startswith("${MIGRATION_EXPIRY_MARKER}")`);
 	});
 
 	test("update-release-pr.yml runs the executable with --no-install, like the scaffold smoke run", () => {
@@ -94,11 +87,17 @@ describe("renderMigrationExpiryTable", () => {
 				expect(result.stderr.toString()).toBe("");
 				expect(result.exitCode).toBe(0);
 				const stdout = result.stdout.toString();
-				expect(stdout.startsWith(`${MIGRATION_EXPIRY_MARKER}\n`)).toBe(true);
-				expect(stdout).toContain("| Migration | Introduced | Expires | Days remaining |");
-				expect(stdout).toMatch(
-					/^\| `[^`]+` \(`src\/extension\/migrations\/[^`]+`\) \| \d{4}-\d{2}-\d{2} \| \d{4}-\d{2}-\d{2} \| -?\d+ \|$/m
-				);
+				// The real registry decides which rendering the workflow must see: a
+				// drained registry renders nothing (the delete path), a live one the
+				// table.
+				if (MIGRATION_EXPIRIES.length === 0) {
+					expect(stdout).toBe("");
+				} else {
+					expect(stdout).toContain("| Migration | Introduced | Expires | Days remaining |");
+					expect(stdout).toMatch(
+						/^\| `[^`]+` \(`src\/extension\/migrations\/[^`]+`\) \| \d{4}-\d{2}-\d{2} \| \d{4}-\d{2}-\d{2} \| -?\d+ \|$/m
+					);
+				}
 			} finally {
 				rmSync(scaffold, { recursive: true, force: true });
 			}

--- a/src/test/bun/scripts/ci/migration-expiry-render.test.ts
+++ b/src/test/bun/scripts/ci/migration-expiry-render.test.ts
@@ -51,12 +51,19 @@ describe("renderMigrationExpiryTable", () => {
 		}
 	});
 
-	test("update-release-pr.yml runs the executable with --no-install, like the scaffold smoke run", () => {
+	test("update-release-pr.yml runs the executable with --no-install and hands the action the PR number", () => {
+		const workflow = readFileSync(join(REPO_ROOT, ".github", "workflows", "update-release-pr.yml"), "utf8");
 		// The workflow has no dependency-install step, and without --no-install
 		// bun silently auto-installs a package import when node_modules is
 		// absent; this pin keeps the flag from being dropped as clutter.
-		const workflow = readFileSync(join(REPO_ROOT, ".github", "workflows", "update-release-pr.yml"), "utf8");
 		expect(workflow).toContain("bun --no-install scripts/ci/migration-expiry-table.ts");
+		// The caller runs on push, so the action learns the release PR only from
+		// this input, and it skips green rather than failing without one: on the
+		// drained-registry path no output betrays the skip, so the wiring is
+		// pinned here.
+		expect(workflow).toMatch(
+			/uses: marocchino\/sticky-pull-request-comment@[0-9a-f]{40} # v\d+\.\d+\.\d+\n\s+with:\n\s+header: migration-expiries\n\s+number: \$\{\{ inputs\.pr_number \}\}\n/
+		);
 	});
 
 	test(


### PR DESCRIPTION
## Summary

Fleet standardization: both repo-owned sticky PR comments now go through `marocchino/sticky-pull-request-comment`, pinned by full sha (v3.0.5).

### Before

```yaml
# update-release-pr.yml: find own comment by body marker, PATCH or POST, delete strays
ids="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
  --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- migration-expiries -->")) | .id')"
...
# dependabot-vscode-floor.yml: post once, marker-scanned, never fail
case "$comments" in *"$marker"*) ;; *) gh pr comment ... || true ;; esac
```

### After

```yaml
# update-release-pr.yml
- uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
  with:
    header: migration-expiries
    number: ${{ inputs.pr_number }}            # workflow_call from a push: no PR in the payload
    path: ${{ runner.temp }}/migration-expiries.md
    delete: ${{ steps.render.outputs.empty }}  # drained registry -> comment removed

# dependabot-vscode-floor.yml
- if: steps.push.outputs.no_retrigger == 'true'
  uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
  with:
    header: dependabot-vscode-floor
    message: |
      Pushed an engines.vscode floor bump with the default workflow token, ...
```

### How

- The action's `header` is the comment identity, so the renderer no longer prints its own `<!-- migration-expiries -->` line.
- The renderer prints nothing for an empty registry; the workflow reads that as `delete: true` (new behavior: no empty table on release PRs).
- The floor notice is a plain upsert now: a posting failure fails the step instead of hiding behind `|| true`.
- One legacy comment exists (the old-marker table on #295); it gets deleted by hand after this merges.

### Proof

- `migration-expiry-render.test.ts`: body pin and `--no-install` pin kept, jq-marker pin dropped with the plumbing, empty-registry pin added; the scaffold smoke test follows the registry's size. 5 passing.
- `bun run lint:actions`, `bunx biome check .`, `bun run typecheck`, `bun run lint:knip` green; pre-commit ran the full `bun run test` chain green.

## Checklist

- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Docs updated if needed
- [x] Follows the conventions in [AGENTS.md](../AGENTS.md)
