### PR TITLE
chore: prepare main for the repo-platform cutover

### DIFF
--- a/.file-size-allow.local
+++ b/.file-size-allow.local
@@ -5,3 +5,4 @@
 src/extension/servers/serverSync/vscodeEnv.ts # l10n.t messages must stay single string literals for @vscode/l10n-dev extraction
 src/provider/transport/errorMapping.ts # l10n.t messages must stay single string literals for @vscode/l10n-dev extraction
 src/webview/dashboard/icons.tsx # inline copies of codicon SVG path data: upstream geometry strings, not authored here
+src/extension/ui/setupGate.ts # l10n.t messages must stay single string literals for @vscode/l10n-dev extraction

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -24,12 +24,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,7 +61,7 @@ jobs:
       hit: ${{ steps.diff.outputs.hit }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -122,14 +122,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history for the crediting-convention guard in the unit suite
           # (src/test/creditConvention.test.ts), same as test-reusable.yml.
           fetch-depth: 0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -160,10 +160,10 @@ jobs:
           - 'docker-monkey'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -191,10 +191,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -221,10 +221,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -260,10 +260,10 @@ jobs:
       catalog: ${{ steps.fetch.outputs.catalog }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -296,7 +296,7 @@ jobs:
 
       - name: Upload the slimmed catalog for format-check
         if: steps.fetch.outputs.catalog == 'fetched'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openrouter-catalog
           path: dist/openrouter-models.json
@@ -338,10 +338,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -361,10 +361,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 

--- a/.github/workflows/close-answered-issues.yml
+++ b/.github/workflows/close-answered-issues.yml
@@ -20,7 +20,7 @@ jobs:
   close:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v11
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           any-of-issue-labels: awaiting-reply
           days-before-issue-stale: 3

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 

--- a/.github/workflows/dependabot-vscode-floor.yml
+++ b/.github/workflows/dependabot-vscode-floor.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
       pull-requests: write # the no-retrigger-token sticky comment below
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # The event's own commit, not the mutable branch: the actor gate
           # authenticates the event, and a branch moved after it must not
@@ -41,7 +41,7 @@ jobs:
           # just loses the push race below and fails loudly.
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
       - name: Raise engines.vscode and the doc floors to the @types/vscode pin

--- a/.github/workflows/dependabot-vscode-floor.yml
+++ b/.github/workflows/dependabot-vscode-floor.yml
@@ -24,9 +24,11 @@ concurrency:
 
 jobs:
   raise-floor:
-    # Dependabot's own pushes only (the fix commit and human pushes must
-    # not re-fire it); same-repo only: the token cannot push to a fork.
-    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot's own pushes only, same-repo only (the token cannot push
+    # to a fork). github.actor on purpose, as in the managed
+    # dependabot-bun-lockfile.yml: gating on the PR author instead would
+    # re-fire on the fix commit this job pushes.
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository # zizmor: ignore[bot-conditions]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/format-check-reusable.yml
+++ b/.github/workflows/format-check-reusable.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -67,7 +67,7 @@ jobs:
       - name: Download the validated OpenRouter catalog
         id: catalog
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.catalog-artifact }}
           path: dist

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -139,10 +139,10 @@ jobs:
           echo "SEED=$SEED" >> "$GITHUB_ENV"
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -267,7 +267,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fuzz-failures-${{ matrix.leg }}-${{ github.run_attempt }}
           path: .fuzz-failures/
@@ -305,7 +305,7 @@ jobs:
         # fuzzing): the action then files its bare no-report notice instead of
         # this step failing on an empty pattern match.
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: fuzz-failures-*
           path: .fuzz-failures

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -37,12 +37,9 @@ concurrency:
   group: nightly-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'scheduled' }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
-# issues: write lets the fuzz-issue action file/close the tracking issue;
-# actions: write lets the failure path dispatch auto-assign at it.
+# The fuzz legs only read; the report job below carries the write scopes.
 permissions:
   contents: read
-  issues: write
-  actions: write
 
 jobs:
   fuzz:
@@ -293,6 +290,12 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # issues: write lets the fuzz-issue action file/close the tracking issue;
+    # actions: write lets the failure path dispatch auto-assign at it.
+    permissions:
+      contents: read
+      issues: write
+      actions: write
     env:
       # Every gh call in this job needs an explicit repo context: the job
       # never checks out the repo, so gh cannot resolve one from a git remote.

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -290,12 +290,10 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # issues: write lets the fuzz-issue action file/close the tracking issue;
-    # actions: write lets the failure path dispatch auto-assign at it.
+    # issues: write lets the fuzz-issue action file/close the tracking issue.
     permissions:
       contents: read
       issues: write
-      actions: write
     env:
       # Every gh call in this job needs an explicit repo context: the job
       # never checks out the repo, so gh cannot resolve one from a git remote.
@@ -315,7 +313,6 @@ jobs:
           merge-multiple: true
 
       - name: File or update the fuzz issue
-        id: file-issue
         if: needs.fuzz.result != 'success'
         uses: Vivswan/repo-platform/actions/fuzz-issue@build
         with:
@@ -324,14 +321,6 @@ jobs:
           title: Nightly fuzz failures
           artifacts-dir: .fuzz-failures
           artifact-name: fuzz-failures-*
-
-      # A GITHUB_TOKEN-created issue fires no triggers, so dispatch auto-assign.
-      - name: Trigger auto-assign for the filed issue
-        if: needs.fuzz.result != 'success' && steps.file-issue.outputs.issue-number != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ steps.file-issue.outputs.issue-number }}
-        run: gh workflow run auto-assign.yml -f "issue=$ISSUE_NUMBER" || echo "::warning::could not dispatch auto-assign.yml"
 
       - name: Close the fuzz issue on a green night
         if: needs.fuzz.result == 'success'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 # The checks job needs only the checkout; the report job scopes its own
-# issue and dispatch permissions below.
+# issue permission below.
 permissions:
   contents: read
 
@@ -54,14 +54,11 @@ jobs:
     # A few gh calls behind a bun setup; a hung reporter is the residual
     # silence window, so keep this tight.
     timeout-minutes: 5
-    # issues: write lets the fuzz-issue action file/close the tracking issue;
-    # actions: write lets the red path dispatch auto-assign at it.
+    # issues: write lets the fuzz-issue action file/close the tracking issue.
     permissions:
       issues: write
-      actions: write
     steps:
       - name: File or update the nightly issue
-        id: file-issue
         if: needs.checks.result == 'failure' || needs.checks.result == 'cancelled'
         uses: Vivswan/repo-platform/actions/fuzz-issue@build
         with:
@@ -75,14 +72,6 @@ jobs:
           # settings-sync declaration.
           label-color: "D93F0B"
           label-description: Automated nightly CI failure
-
-      # A GITHUB_TOKEN-created issue fires no triggers, so dispatch auto-assign.
-      - name: Trigger auto-assign for the filed issue
-        if: steps.file-issue.outputs.issue-number != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ steps.file-issue.outputs.issue-number }}
-        run: gh workflow run auto-assign.yml -f "issue=$ISSUE_NUMBER" || echo "::warning::could not dispatch auto-assign.yml"
 
       - name: Close the nightly issue on a green night
         if: needs.checks.result == 'success'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Set up whatever the nightly checks need here (toolchains, docker,
       # service containers, caches, ...). Add sibling jobs freely: list

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -86,7 +86,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
           # Full history: the crediting-convention guard in the unit suite
@@ -95,7 +95,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 
@@ -123,13 +123,17 @@ jobs:
         shell: bash
         env:
           DOCKER_ONLY: ${{ inputs.docker-only }}
+          SUITE_SCRIPT: ${{ inputs.suite == 'docker' && 'test:docker' || 'test:coverage' }}
         run: |
           if [ -n "$DOCKER_ONLY" ]; then
             xvfb-run -a bun run test:docker --only "$DOCKER_ONLY"
           else
-            xvfb-run -a bun run ${{ inputs.suite == 'docker' && 'test:docker' || 'test:coverage' }}
+            xvfb-run -a bun run "$SUITE_SCRIPT"
           fi
 
       - name: Run tests (Windows/macOS)
         if: runner.os != 'Linux'
-        run: bun run ${{ inputs.suite == 'docker' && 'test:docker' || 'test' }}
+        shell: bash
+        env:
+          SUITE_SCRIPT: ${{ inputs.suite == 'docker' && 'test:docker' || 'test' }}
+        run: bun run "$SUITE_SCRIPT"

--- a/.github/workflows/update-release-pr.yml
+++ b/.github/workflows/update-release-pr.yml
@@ -43,10 +43,10 @@ jobs:
       # inputs.head_branch provenance is unused here because the expiry
       # table describes what the release will ship, not the PR's diff.
       - name: Checkout source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -35,12 +35,12 @@ jobs:
       contents: write # also what makes the draft visible to gh
     steps:
       - name: Checkout released source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
 

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -47,6 +47,7 @@ knip.json
 .repo-platform.yml
 .typography-allow
 .typography-allow.local
+_typos.toml
 
 # Repository docs and release automation (not needed at runtime)
 docs/**

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,24 @@
+# This repository's own typos allowlist; the fleet allowlist in
+# repo-platform's actions/typos/_typos.toml applies underneath it. One-off
+# fixtures that misspell on purpose carry a `// typos: ignore` line marker.
+
+[default]
+extend-ignore-re = [
+  # The plural of catch-all (matcher records, router routes).
+  "\\bcatch-alls\\b",
+  # The deliberate misspelling the settings reference and its generator test
+  # use as the example of an unknown key, in prose and as an escaped regex.
+  "\\bchat\\\\?\\.timout\\b",
+]
+
+[default.extend-identifiers]
+# Acronym plurals typos splits at the case change.
+PNGs = "PNGs"
+IIFEs = "IIFEs"
+# Test fixtures spell cafe with an escaped e-acute (café); the escape
+# ends the identifier, so only the bare token is exempt.
+caf = "caf"
+
+[default.extend-words]
+# look-alikes (Unicode confusables of the sanctioned marks).
+alikes = "alikes"

--- a/src/dashboard/presenters.ts
+++ b/src/dashboard/presenters.ts
@@ -165,7 +165,11 @@ export function zeroModelEnglishDetail(hiddenCount: number, answeredCount: numbe
  * land in public issue reports.
  */
 function entryInactiveText(subject: string): string {
-	return `${subject} (the provider group does not carry this entry's labeled identity); delete the group in Manage Language Models (or remove its object from the models file, chatLanguageModels.json, and reload the window), then run Sync Models Now, or save the entry under a new label`;
+	return (
+		`${subject} (the provider group does not carry this entry's labeled identity); ` +
+		"delete the group in Manage Language Models (or remove its object from the models file, chatLanguageModels.json, and reload the window), " +
+		"then run Sync Models Now, or save the entry under a new label"
+	);
 }
 
 const ENTRY_PARAMS_INACTIVE_TEXT = entryInactiveText("per-entry modelParameters are not applied");

--- a/src/extension/servers/serverSync/engine.ts
+++ b/src/extension/servers/serverSync/engine.ts
@@ -271,7 +271,9 @@ export const GROUP_UPSERT_FAILED_MESSAGE = "The host rejected the provider group
  * exists (pinned by hostGroupCommand.test.ts).
  */
 export const GROUP_UPDATE_UNAVAILABLE_MESSAGE =
-	"A VS Code provider group already uses this name, and VS Code cannot update an existing group. If the group does not match this entry, delete it in Manage Language Models (or remove its object from the models file, chatLanguageModels.json, and reload the window), then run Sync Models Now.";
+	"A VS Code provider group already uses this name, and VS Code cannot update an existing group. " +
+	"If the group does not match this entry, delete it in Manage Language Models (or remove its object from the models file, chatLanguageModels.json, and reload the window), " +
+	"then run Sync Models Now.";
 
 /**
  * The classified text for an entry whose stored secrets could not be read this

--- a/src/test/bun/dashboard/presenters.test.ts
+++ b/src/test/bun/dashboard/presenters.test.ts
@@ -366,7 +366,9 @@ describe("dashboard/presenters renderers", () => {
 			// Each notice is its own subject plus the clause the composer appends;
 			// the clause is pinned here once, as users paste it into issue reports.
 			const clause =
-				" (the provider group does not carry this entry's labeled identity); delete the group in Manage Language Models (or remove its object from the models file, chatLanguageModels.json, and reload the window), then run Sync Models Now, or save the entry under a new label";
+				" (the provider group does not carry this entry's labeled identity); " +
+				"delete the group in Manage Language Models (or remove its object from the models file, chatLanguageModels.json, and reload the window), " +
+				"then run Sync Models Now, or save the entry under a new label";
 			const notices = [
 				"entry-params-inactive",
 				"entry-capabilities-inactive",

--- a/src/test/bun/provider/transport/textToolCallParser.property.test.ts
+++ b/src/test/bun/provider/transport/textToolCallParser.property.test.ts
@@ -171,15 +171,15 @@ describe("provider/textToolCallParser chunking invariance properties", () => {
 	test("strippable tokens split across chunk boundaries never leak into visible text", () => {
 		const cases: Array<[string, string]> = [
 			["a<|x_sec", "tion_begin|>b"],
-			["a<|tool_call_e", "nd|>b"],
-			["a<|tool_call_argument_e", "nd|>b"],
+			["a<|tool_call_e", "nd|>b"], // typos: ignore
+			["a<|tool_call_argument_e", "nd|>b"], // typos: ignore
 			["a<|tool_call_argument_end|", ">b"],
 		];
 		{
 			const parser = new TextToolCallParser();
 			const events = [
 				...parser.push('<|tool_call_begin|>t<|tool_call_argument_begin|>{"x":1}<|tool_call_argument_e').events,
-				...parser.push("nd|><|tool_call_end|>").events,
+				...parser.push("nd|><|tool_call_end|>").events, // typos: ignore
 				...parser.flush().events,
 			];
 			const calls = events.filter((event) => event.type === "call");

--- a/src/test/bun/scripts/docs/generateSettingsReference.test.ts
+++ b/src/test/bun/scripts/docs/generateSettingsReference.test.ts
@@ -261,7 +261,7 @@ describe("generate-settings-reference CLI", () => {
 			// A typo'd --check must not fall through to generate mode and rewrite docs.
 			const root = makeFixture();
 			const before = fs.readFileSync(path.join(root, SETTINGS_DOC_PATHS.en), "utf8");
-			const typo = runCli(root, "--chekc");
+			const typo = runCli(root, "--chekc"); // typos: ignore
 			assert.strictEqual(typo.exitCode, 1);
 			assert.match(typo.stderr, /unknown argument/);
 			assert.strictEqual(fs.readFileSync(path.join(root, SETTINGS_DOC_PATHS.en), "utf8"), before);

--- a/src/test/bun/shared/conversion/textTokens.test.ts
+++ b/src/test/bun/shared/conversion/textTokens.test.ts
@@ -196,7 +196,7 @@ describe("shared/conversion/textTokens: the non-Latin detection threshold", () =
 	test("Latin-script European text and typographic punctuation never fire", () => {
 		assert.strictEqual(detections("a".repeat(4000)), 0);
 		// Accented Latin (French) stays below the 0x0370 line.
-		assert.strictEqual(detections("Réécrivez cette fonction en une fonction pure, s'il vous plaît déjà."), 0);
+		assert.strictEqual(detections("Réécrivez cette fonction en une fonction pure, s'il vous plaît déjà."), 0); // typos: ignore
 		// Curly quotes and dashes live in the excluded 0x2000-0x2E7F blocks
 		// (escaped so the fixture itself passes the repo's typography gate).
 		assert.strictEqual(detections("\u201Cquoted\u201D \u2014 \u2018more\u2019 \u2013 again".repeat(4)), 0);

--- a/src/test/dockerTestLabels.test.ts
+++ b/src/test/dockerTestLabels.test.ts
@@ -37,10 +37,10 @@ suite("dockerTestLabels: parseOnlyLabels", () => {
 
 	test("an unknown label throws naming it and every known label", () => {
 		assert.throws(
-			() => parseOnlyLabels("docker,docker-transprot"),
+			() => parseOnlyLabels("docker,docker-transprot"), // typos: ignore
 			(error: unknown) => {
 				const message = error instanceof Error ? error.message : String(error);
-				assert.ok(message.includes('unknown label "docker-transprot"'), message);
+				assert.ok(message.includes('unknown label "docker-transprot"'), message); // typos: ignore
 				for (const label of DOCKER_TEST_LABELS) {
 					assert.ok(message.includes(label), `error message names ${label}: ${message}`);
 				}

--- a/src/test/extension/features/participant/wiring.test.ts
+++ b/src/test/extension/features/participant/wiring.test.ts
@@ -296,7 +296,7 @@ suite("extension/features/participant wiring", () => {
 			});
 			const handler = spies.participants[0]?.handler;
 			assert.ok(handler !== undefined);
-			const { request, sends } = fakeRequest({ prompt: "explain this", fragments: ["Hel", "lo"] });
+			const { request, sends } = fakeRequest({ prompt: "explain this", fragments: ["Hel", "lo"] }); // typos: ignore
 			const { stream, reported } = recordingStream();
 			const source = new vscode.CancellationTokenSource();
 			try {
@@ -306,7 +306,7 @@ suite("extension/features/participant wiring", () => {
 			}
 			assert.strictEqual(sends.length, 1, "exactly one request, to the request's own model");
 			assert.strictEqual(sends[0]?.token, source.token, "the turn's token must ride along so cancel works");
-			assert.deepStrictEqual(reported, ["Hel", "lo"], "fragments forward in order, unmerged");
+			assert.deepStrictEqual(reported, ["Hel", "lo"], "fragments forward in order, unmerged"); // typos: ignore
 			const [message] = sends[0]?.messages ?? [];
 			assert.strictEqual(message?.role, vscode.LanguageModelChatMessageRole.User);
 		});

--- a/src/test/monkeyFuzz.ts
+++ b/src/test/monkeyFuzz.ts
@@ -1329,7 +1329,7 @@ export class MonkeySession {
 		const alias = PLAYBACK_MODEL.alias;
 		const values: Record<ParamShape, Record<string, Record<string, unknown>>> = {
 			plain: { [alias]: { temperature, seed: 1000 + action.serial } },
-			invalid: { [alias]: { _monkey: action.serial, model: "monkey-hax-model" } },
+			invalid: { [alias]: { _monkey: action.serial, model: "monkey-hijack-model" } },
 			forced: { [alias]: { temperature, _force: true } },
 			inherited: { "*": { top_p: 0.75, _inheritable: true }, [alias]: { temperature } },
 			barrier: {
@@ -1401,8 +1401,12 @@ export class MonkeySession {
 				);
 				return;
 			case "invalid":
-				assert.notStrictEqual(wire.model, "monkey-hax-model", "the provider-owned model field must not be overridable");
-				assert.ok(!reply.includes("monkey-hax-model"), "%params must not report a hijacked model");
+				assert.notStrictEqual(
+					wire.model,
+					"monkey-hijack-model",
+					"the provider-owned model field must not be overridable"
+				);
+				assert.ok(!reply.includes("monkey-hijack-model"), "%params must not report a hijacked model");
 				return;
 			case "forced":
 				assert.strictEqual(wire.temperature, temperature, "a forced field must beat the runtime option");

--- a/src/test/provider/transport/streamingModernFields.test.ts
+++ b/src/test/provider/transport/streamingModernFields.test.ts
@@ -646,7 +646,7 @@ suite("provider/streaming generated media", () => {
 		const stream = mediaProcessor();
 		const { parts, progress } = collector();
 
-		stream.processDelta({ choices: [{ delta: { audio: { id: "a1", data: "U", transcript: "Hel" } } }] }, progress);
+		stream.processDelta({ choices: [{ delta: { audio: { id: "a1", data: "U", transcript: "Hel" } } }] }, progress); // typos: ignore
 		stream.processDelta({ choices: [{ delta: { audio: { data: "klGRg==", transcript: "lo" } } }] }, progress);
 		stream.processDelta(finish, progress);
 

--- a/src/test/scenarios.ts
+++ b/src/test/scenarios.ts
@@ -333,7 +333,7 @@ export const BUILTIN_SCENARIOS: Record<string, Scenario> = {
 		type: "sse",
 		chunks: [
 			makeChunk({ role: "assistant", content: "Checking the weather. <|tool_call_begin|>get_wea" }),
-			makeChunk({ content: 'ther:0<|tool_call_argument_begin|>{"location":' }),
+			makeChunk({ content: 'ther:0<|tool_call_argument_begin|>{"location":' }), // typos: ignore
 			makeChunk({ content: '"Paris"}<|tool_call_end|>' }),
 			makeChunk({}, "stop"),
 		],

--- a/src/webview/dashboard/styles/dashboard.css
+++ b/src/webview/dashboard/styles/dashboard.css
@@ -4182,7 +4182,7 @@
 		}
 		/* The chips take a full line of their own: sharing the matcher's line
 		 squeezed them into a column a word wide, and chip keys break anywhere,
-		 so "temperature" printed as tem-per-a-ture down the row. */
+		 so "temperature" came out stacked a few letters per line. */
 		.record-table .chip-list {
 			flex: 1 1 100%;
 		}


### PR DESCRIPTION
## What this changes

Main prepared for the repo-platform cutover: the fleet checks that ran red on cloud-speech's cutover PR now pass here.

```text
$ typos --config <fleet>/actions/typos/_typos.toml .          # exit 0 (was 35 findings)
$ bun <fleet>/actions/check-file-size/check-file-size.ts .   # File size check passed (was 4 lines over the 256-char cap)
$ semgrep scan --config p/default .                          # 0 ERROR findings outside managed files (was 2: run-shell-injection)
$ zizmor --config <fleet>/actions/zizmor/zizmor.yml --min-severity high .   # No findings (was 3 high: excessive-permissions x2, bot-conditions)
$ grep -rE "uses: [^./].*@v[0-9]" repo-owned workflows       # nothing (was 39 tag refs across 11 workflows)
```

## How

| Concern | Change |
| --- | --- |
| Unpinned actions | `actions/checkout`, `oven-sh/setup-bun`, `actions/upload-artifact`, `actions/download-artifact`, `actions/stale` pinned to the sha of their current tag with a `# vX.Y.Z` comment, in every workflow the manifest classes as starter or does not list. Managed workflows untouched. |
| Typos | Root `_typos.toml` extends the fleet allowlist: `catch-alls`, `chat.timout` (the docs' deliberate example), `PNGs`, `IIFEs`, the `café` fixture token, `look-alikes`. Fixtures that misspell on purpose carry `// typos: ignore`. Two real fixes: the `monkey-hax-model` fixture renamed, a CSS comment reworded. `_typos.toml` joins `.vscodeignore` so the packaged-file-list check stays green. |
| Width cap | Three over-wide string lines wrapped to concatenations with the same value. `setupGate.ts` joins `.file-size-allow.local` beside the two existing l10n entries: an `l10n.t` key must stay one literal for extraction. |
| Semgrep | The reusable test workflow's `${{ inputs.suite ... }}` expression moves from the `run:` line into an `env:` variable. |
| Zizmor | The nightly workflows' `issues: write` moves onto the report job, and their redundant `gh workflow run auto-assign.yml` step goes with the `actions: write` scope only it needed (the fuzz-issue action already assigns the owner at creation). The dependabot floor workflow's deliberate `github.actor` gate carries an inline zizmor ignore with its reason, as the fleet policy records for its managed twin. |

## Proof

- `bun run test` (bun tree plus the four host labels), `typecheck`, `lint`, `lint:types`, `lint:knip`, `lint:actions`, `l10n:check`, `biome check` all green locally.
- Negative controls for the typos allowlist: `request.timout` and `cafCount` still flag; `chat.timout`, `/chat\.timout/` and `café` do not.

