### PR TITLE
build(deps-dev): bump @types/react-dom from 19.2.5 to 19.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.4.1",
         "@types/react": "^19.2.18",
-        "@types/react-dom": "^19.2.5",
+        "@types/react-dom": "^19.3.0",
         "@types/vscode": "1.136.0",
         "@vscode/l10n-dev": "^0.0.35",
         "@vscode/test-cli": "^0.0.15",

--- a/package.json
+++ b/package.json
@@ -1256,7 +1256,7 @@
 		"@types/mocha": "^10.0.10",
 		"@types/node": "^26.4.1",
 		"@types/react": "^19.2.18",
-		"@types/react-dom": "^19.2.5",
+		"@types/react-dom": "^19.3.0",
 		"@types/vscode": "1.136.0",
 		"@vscode/l10n-dev": "^0.0.35",
 		"@vscode/test-cli": "^0.0.15",


### PR DESCRIPTION
## What this changes

```text
$ git diff main --stat
 bun.lock     | 2 +-
 package.json | 2 +-

-        "@types/react-dom": "^19.2.5",
+        "@types/react-dom": "^19.3.0",
```

The resolved `@types/react-dom@19.3.0` entry in the lockfile is unchanged; only the declared range moves up to it.

## How

Supersedes #323. Dependabot could not rebase that PR: its bun runner reads `bun.lock` lockfileVersion 1 and this lockfile has been version 2 since #321. `bun update @types/react-dom` on current main produces this two-line diff.

## Proof

- `bun install --frozen-lockfile`, `typecheck` (all four projects, `src/webview` included), `lint`, `biome check`, the bun test tree, and the full pre-commit chain green.
