### PR TITLE
docs: drop the scheduled-run clause from the catalog fetch wording

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,7 +81,7 @@ jobs:
           # what --only runs.
           pattern='^src/test/(bun/)?(fuzz|monkey|scenarios|fakeStack/|docker-(fuzz|conversation|monkey)\.test\.ts)|^src/test/bun/preload\.ts$|^bunfig\.toml$|^src/provider/transport/streaming/|^scripts/stack/fake-openai-server\.ts$|^scripts/docker-test\.ts$|^src/test/dockerTestLabels\.ts$|\.property\.test\.ts$'
           if [ "$EVENT" != "push" ] && [ "$EVENT" != "pull_request" ]; then
-            # Scheduled and dispatched gate runs have no diff to inspect.
+            # Dispatched gate runs have no diff to inspect.
             echo "hit=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -273,8 +273,8 @@ jobs:
       # ::warning:: headline says which) is one ::warning:: annotation and
       # exit 0 with nothing written, because a third-party failure must not
       # block landing on main; schema drift stays fatal in every mode. Pull
-      # request runs, ci.yml's weekly schedule, and manual dispatch stay fatal,
-      # so the failure is still caught loudly where a human is watching and a
+      # request runs and manual dispatch stay fatal, so the failure is still
+      # caught loudly where a human is watching and a
       # re-run is cheap, and the release build's own fetch (vscode:prepublish)
       # stays fatal too. The file, not the exit code, says whether the catalog
       # was fetched.

--- a/scripts/dev/openRouterCatalogFetch.ts
+++ b/scripts/dev/openRouterCatalogFetch.ts
@@ -90,8 +90,8 @@ export function unreachableVerdict(error: UnreachableError): { readonly headline
  * UnreachableError is fatal by default; under `unreachableIsWarning` it is one
  * GitHub `::warning::` line carrying the evidence and exit 0, whatever its
  * reason, headlined by unreachableVerdict. Push-to-main builds opt in, so a
- * third-party outage does not block landing; pull request runs, ci.yml's weekly
- * schedule, manual dispatch, and the release build's own fetch stay fatal, so
+ * third-party outage does not block landing; pull request runs, manual
+ * dispatch, and the release build's own fetch stay fatal, so
  * an outage is still caught loudly where a re-run is cheap.
  */
 export type FailureExit = { readonly exitCode: 0; readonly warning: string } | { readonly exitCode: 1 };
@@ -102,7 +102,7 @@ export function failureExit(error: unknown, options: { readonly unreachableIsWar
 			exitCode: 0,
 			warning:
 				`::warning::${unreachableVerdict(error).headline}: ${error.message}; ` +
-				"skipping the live catalog check on this push - pull request runs, ci.yml's weekly schedule, and release builds still fail on it",
+				"skipping the live catalog check on this push - pull request runs, manual dispatch, and release builds still fail on it",
 		};
 	}
 	return { exitCode: 1 };

--- a/src/test/bun/scripts/dev/openRouterCatalogFetch.test.ts
+++ b/src/test/bun/scripts/dev/openRouterCatalogFetch.test.ts
@@ -341,7 +341,7 @@ describe("failureExit", () => {
 	const settled = new UnreachableError({ kind: "http", status: 404 }, `HTTP 404 from ${OPENROUTER_MODELS_URL}`);
 	const drift = new DriftError("payload yields 3 usable models (floor 100)");
 	const skipTail =
-		"skipping the live catalog check on this push - pull request runs, ci.yml's weekly schedule, " +
+		"skipping the live catalog check on this push - pull request runs, manual dispatch, " +
 		"and release builds still fail on it";
 	const cases: readonly {
 		readonly name: string;


### PR DESCRIPTION
## What this changes

```text
$ grep -rn "weekly schedule\|Scheduled and dispatched" scripts src .github/workflows/checks.yml
(no matches)
```

Since the fleet CI cutover, the managed `ci.yml` calls `checks.yml` only off the schedule, so the OpenRouter catalog job never runs on one. Three repo-owned texts still said the fetch "stays fatal on ci.yml's weekly schedule"; they now name only the runs that still fail loudly on an unreachable catalog.

## How

| Site | Was | Now |
| --- | --- | --- |
| `scripts/dev/openRouterCatalogFetch.ts` skip message and doc comment | pull request runs, ci.yml's weekly schedule, manual dispatch, release build | pull request runs, manual dispatch, release build |
| `src/test/bun/scripts/dev/openRouterCatalogFetch.test.ts` pinned string | same | same |
| `.github/workflows/checks.yml` two comments | "ci.yml's weekly schedule", "Scheduled and dispatched gate runs" | dropped the schedule clause |

## Proof

- The catalog fetch suite (33 tests) still pins the message byte for byte; `typecheck`, `lint:actions`, `biome check`, and the pre-commit chain green.
